### PR TITLE
Foundation pass: site-aware scope, BlockId migration, room-time loader, and deterministic solver refactor

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,11 +1,7 @@
-"""Application configuration.
-
-All tunable parameters live here.  Import the module-level ``CONFIG``
-instance everywhere; override individual fields as needed before the
-experiment starts.
-"""
+"""Application configuration."""
 
 from dataclasses import dataclass, field
+from typing import Tuple
 
 
 @dataclass
@@ -21,55 +17,19 @@ class DataConfig:
 
 @dataclass
 class CapacityConfig:
-    """Block capacity and activation cost (paper Section 4.2).
-
-    Blocks are *candidate* slots that the planner may open at cost
-    ``activation_cost_per_block``.  The candidate pool is built from
-    training-period weekday room patterns filtered by activation
-    regularity.
-
-    Capacity is day-specific: ``friday_capacity_minutes`` allows a
-    shorter nominal block on Fridays, matching the empirical finding
-    that Friday spans are ~45 min shorter than Mon–Thu.
-    """
     block_capacity_minutes: float = 480.0
     friday_capacity_minutes: float = 450.0
     activation_cost_per_block: float = 2000.0
-
-    # Template filtering: only include room-day pairs that were active
-    # in at least this fraction of training weeks.  The data report
-    # shows 153/168 templates activate ≥ 50% of weeks; setting this
-    # to 0.25 is conservative and keeps the pool realistic.
     min_activation_rate: float = 0.25
-
-    # Mean turnover between consecutive cases in the same block (minutes).
-    # Used to adjust effective capacity: C_eff = C - (avg_cases - 1) * turnover.
-    # Set to 0.0 to disable turnover adjustment.
-    # The data report shows mean turnover of 28.3 min (capped at 60 min).
-    mean_turnover_minutes: float = 28.0
+    turnover_minutes: float = 32.0
+    eligibility_min_weeks: int = 3
+    fixed_block_threshold: float = 0.75
 
 
 @dataclass
 class EligibilityConfig:
-    """Controls how case-level eligibility sets B_ti are built.
-
-    The paper's formulation (Section 3.5) restricts each case to
-    B_ti ⊆ B_t based on service compatibility, site, and surgeon
-    history.  The data report shows room sets are NOT disjoint across
-    services but ARE nearly disjoint across sites.
-    """
-    # Hard filter: case can only go to blocks whose room has historically
-    # served the case's surgical service.
     use_service_room_filter: bool = True
-
-    # Hard filter: case can only go to blocks at the same site as the
-    # case's historical operating room.  Nearly free because sites are
-    # almost room-disjoint in the UHN data.
     use_site_filter: bool = True
-
-    # Soft narrowing: if enabled, restrict each case to blocks in the
-    # surgeon's top-K historical room-day templates, with fallback to
-    # service-level eligibility if the surgeon has too few templates.
     use_surgeon_preference: bool = False
     surgeon_top_k_templates: int = 5
     surgeon_min_cases_for_preference: int = 30
@@ -77,13 +37,6 @@ class EligibilityConfig:
 
 @dataclass
 class CostConfig:
-    """Operational cost coefficients (paper Section 4.2).
-
-    ``deferral_per_case`` is a flat per-case penalty — every deferred
-    patient incurs the same access cost regardless of case complexity.
-    Case-level heterogeneity in resource consumption is captured by
-    block-load constraints, not by the deferral penalty.
-    """
     overtime_per_minute: float = 15.0
     idle_per_minute: float = 10.0
     deferral_per_case: float = 2000.0
@@ -94,8 +47,22 @@ class CostConfig:
 class SolverConfig:
     time_limit_seconds: int = 600
     mip_gap: float = 0.05
-    threads: int = 0        # 0 = let Gurobi decide
+    threads: int = 0
     verbose: bool = False
+
+
+@dataclass
+class SurgeonGroupingConfig:
+    default_max_blocks_per_day: int = 1
+    adaptive_relaxation: bool = True
+
+
+@dataclass
+class ExperimentScopeConfig:
+    planning_sites: Tuple[str, ...] = ("TGH", "TWH")
+    planning_weekdays: Tuple[int, ...] = (0, 1, 2, 3, 4)
+    use_all_sites_for_warmup: bool = True
+    stride_days: int = 7
 
 
 @dataclass
@@ -105,6 +72,8 @@ class Config:
     eligibility: EligibilityConfig = field(default_factory=EligibilityConfig)
     costs: CostConfig = field(default_factory=CostConfig)
     solver: SolverConfig = field(default_factory=SolverConfig)
+    surgeon_grouping: SurgeonGroupingConfig = field(default_factory=SurgeonGroupingConfig)
+    scope: ExperimentScopeConfig = field(default_factory=ExperimentScopeConfig)
 
 
 CONFIG = Config()

--- a/src/core/types.py
+++ b/src/core/types.py
@@ -1,58 +1,54 @@
-"""Canonical data types shared across the entire project.
-
-These types form the interface contract between data loading, methods,
-solvers, and evaluation.  Every module communicates through these objects
-rather than through raw DataFrames or dictionaries, which prevents silent
-schema drift.
-"""
+"""Canonical data types shared across the project."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import date, datetime
-from typing import Dict, FrozenSet, List, Optional, Set, Tuple
+from typing import Dict, List, NamedTuple, Optional, Set, Tuple
 
-
-# ─── Column name constants ───────────────────────────────────────────────────
 
 class Col:
-    """Canonical DataFrame column names."""
-    PATIENT_ID          = "patient_id"
-    PATIENT_TYPE        = "patient_type"
-    CASE_SERVICE        = "case_service"
-    MAIN_PROCEDURE      = "main_procedure"
-    PROCEDURE_ID        = "main_procedure_id"
-    OPERATING_ROOM      = "operating_room"
-    SURGEON             = "surgeon"
-    SURGEON_CODE        = "surgeon_code"
-    BOOKED_MINUTES      = "booked_time_minutes"
-    ACTUAL_START        = "actual_start"
-    ACTUAL_STOP         = "actual_stop"
-    ENTER_ROOM          = "enter_room"
-    LEAVE_ROOM          = "leave_room"
-    PROCEDURE_DURATION  = "procedure_duration_min"
+    PATIENT_ID = "patient_id"
+    PATIENT_TYPE = "patient_type"
+    CASE_SERVICE = "case_service"
+    MAIN_PROCEDURE = "main_procedure"
+    PROCEDURE_ID = "main_procedure_id"
+    OPERATING_ROOM = "operating_room"
+    SURGEON = "surgeon"
+    SURGEON_CODE = "surgeon_code"
+    BOOKED_MINUTES = "booked_time_minutes"
+    ACTUAL_START = "actual_start"
+    ACTUAL_STOP = "actual_stop"
+    ENTER_ROOM = "enter_room"
+    LEAVE_ROOM = "leave_room"
+    PROCEDURE_DURATION = "procedure_duration_min"
     PREPARATION_DURATION = "preparation_duration_min"
-    WEEK_OF_YEAR        = "week_of_year"
-    MONTH               = "month"
-    YEAR                = "year"
+    WEEK_OF_YEAR = "week_of_year"
+    MONTH = "month"
+    YEAR = "year"
 
-    # Original Excel column pairs (date + time) — used only during loading
+    SITE = "site"
+    SURGICAL_DURATION = "surgical_duration_min"
+    ROOM_DURATION = "room_duration_min"
+    USED_ROOM_TIME = "used_room_time"
+    FELL_BACK_SURGICAL = "fell_back_to_surgical"
+    TIMESTAMP_VIOLATION = "timestamp_violation"
+    OVERHEAD_CAPPED = "overhead_capped"
+    CASE_UID = "case_uid"
+
     ACTUAL_START_DATE = "actual_start_date"
     ACTUAL_START_TIME = "actual_start_time"
-    ACTUAL_STOP_DATE  = "actual_stop_date"
-    ACTUAL_STOP_TIME  = "actual_stop_time"
-    ENTER_ROOM_DATE   = "enter_room_date"
-    ENTER_ROOM_TIME   = "enter_room_time"
-    LEAVE_ROOM_DATE   = "leave_room_date"
-    LEAVE_ROOM_TIME   = "leave_room_time"
+    ACTUAL_STOP_DATE = "actual_stop_date"
+    ACTUAL_STOP_TIME = "actual_stop_time"
+    ENTER_ROOM_DATE = "enter_room_date"
+    ENTER_ROOM_TIME = "enter_room_time"
+    LEAVE_ROOM_DATE = "leave_room_date"
+    LEAVE_ROOM_TIME = "leave_room_time"
 
-
-# ─── Domain constants ────────────────────────────────────────────────────────
 
 class Domain:
-    """Numerical and categorical constants."""
-    MIN_PROCEDURE_DURATION = 30        # minutes
-    MAX_OVERTIME_PER_BLOCK = 240       # minutes
+    MIN_PROCEDURE_DURATION = 30
+    MAX_OVERTIME_PER_BLOCK = 240
     OR_ROOM_PREFIX = "OR"
     EMERGENCY_PATIENT = "EMERGENCY PATIENT"
     OTHER = "Other"
@@ -60,16 +56,18 @@ class Domain:
     EMERGENCY_ROOMS = ("OREMER", "ORER")
 
 
-# ─── Record types ────────────────────────────────────────────────────────────
+class BlockId(NamedTuple):
+    day_index: int
+    site: str
+    room: str
+
+
+EligibilityMap = Dict[str, Set[Tuple[str, str]]]
+SurgeonDaySiteCases = Dict[Tuple[str, int, str], List[int]]
+
 
 @dataclass
 class CaseRecord:
-    """One elective surgery case.
-
-    Methods receive these in a ``WeeklyInstance``.  The contract is that a
-    method's ``plan()`` must NOT read ``actual_duration_min`` — that field
-    exists solely for evaluation after scheduling.
-    """
     case_id: int
     procedure_id: str
     surgeon_code: str
@@ -77,65 +75,56 @@ class CaseRecord:
     patient_type: str
     operating_room: str
     booked_duration_min: float
-    actual_duration_min: float      # evaluation only — do not use in plan()
+    actual_duration_min: float
     actual_start: datetime
     week_of_year: int
     month: int
     year: int
-
-
-# ─── Block types ─────────────────────────────────────────────────────────────
-
-# A block is identified by a (day_index, block_index) tuple throughout.
-BlockId = Tuple[int, int]
+    site: str = ""
+    surgical_duration_min: float = 0.0
 
 
 @dataclass(frozen=True)
 class CandidateBlock:
-    """One OR block that *could* be opened in a planning week.
-
-    The planner decides which candidates to open (staff) at activation
-    cost ``activation_cost``.  Cases can only be assigned to opened blocks.
-    """
     day_index: int
-    block_index: int
+    site: str
     room: str
     capacity_minutes: float
     activation_cost: float
+    is_fixed: bool = False
 
     @property
     def id(self) -> BlockId:
-        return (self.day_index, self.block_index)
+        return BlockId(self.day_index, self.site, self.room)
 
 
 @dataclass
 class BlockCalendar:
-    """Candidate OR blocks for one planning week.
-
-    ``candidates`` lists every block that *could* be opened.  The solver
-    decides which ones to actually staff.  This replaces the old design
-    where ``daily_counts`` specified a fixed number of guaranteed blocks.
-    """
     candidates: List[CandidateBlock]
 
     @property
     def block_ids(self) -> List[BlockId]:
-        """Flat list of (day_index, block_index) identifiers."""
         return [c.id for c in self.candidates]
 
     @property
     def total_candidates(self) -> int:
         return len(self.candidates)
 
+    @property
+    def fixed_blocks(self) -> List[CandidateBlock]:
+        return [c for c in self.candidates if c.is_fixed]
+
+    @property
+    def flex_blocks(self) -> List[CandidateBlock]:
+        return [c for c in self.candidates if not c.is_fixed]
+
     def capacity(self, block_id: BlockId) -> float:
-        """Nominal capacity of a specific candidate block."""
         for c in self.candidates:
             if c.id == block_id:
                 return c.capacity_minutes
         raise KeyError(f"Block {block_id} not in calendar.")
 
     def activation_cost(self, block_id: BlockId) -> float:
-        """Activation cost of a specific candidate block."""
         for c in self.candidates:
             if c.id == block_id:
                 return c.activation_cost
@@ -144,21 +133,20 @@ class BlockCalendar:
     def blocks_on_day(self, day: int) -> List[CandidateBlock]:
         return [c for c in self.candidates if c.day_index == day]
 
+    def blocks_by_site_day(self, site: str, day: int) -> List[CandidateBlock]:
+        return [c for c in self.candidates if c.site == site and c.day_index == day]
 
-# ─── Instance type ───────────────────────────────────────────────────────────
 
 @dataclass
 class WeeklyInstance:
-    """Everything needed to plan one week and evaluate the result.
-
-    The ``cases`` list is the candidate set.  A method must assign each
-    case to an opened block or defer it.
-    """
     week_index: int
     start_date: date
     end_date: date
     cases: List[CaseRecord]
     calendar: BlockCalendar
+    eligibility: EligibilityMap = field(default_factory=dict)
+    case_eligible_blocks: Dict[int, List[BlockId]] = field(default_factory=dict)
+    surgeon_day_site_cases: SurgeonDaySiteCases = field(default_factory=dict)
 
     @property
     def num_cases(self) -> int:
@@ -171,14 +159,12 @@ class WeeklyInstance:
         return [c.actual_duration_min for c in self.cases]
 
 
-# ─── Schedule types ──────────────────────────────────────────────────────────
-
 @dataclass
 class ScheduleAssignment:
-    """One case's scheduling decision."""
     case_id: int
-    day_index: Optional[int] = None     # None → deferred
-    block_index: Optional[int] = None   # None → deferred
+    day_index: Optional[int] = None
+    site: Optional[str] = None
+    room: Optional[str] = None
 
     @property
     def is_deferred(self) -> bool:
@@ -188,12 +174,11 @@ class ScheduleAssignment:
     def block_id(self) -> Optional[BlockId]:
         if self.is_deferred:
             return None
-        return (self.day_index, self.block_index)
+        return BlockId(self.day_index, self.site or "", self.room or "")
 
 
 @dataclass
 class ScheduleResult:
-    """Complete output of a method's ``plan()`` call."""
     assignments: List[ScheduleAssignment]
     opened_blocks: Set[BlockId] = field(default_factory=set)
     solver_status: str = "Unknown"
@@ -207,12 +192,8 @@ class ScheduleResult:
         return [a for a in self.assignments if a.is_deferred]
 
 
-# ─── Evaluation types ────────────────────────────────────────────────────────
-
 @dataclass
 class KPIResult:
-    """Operational KPIs produced by evaluating a schedule against realized
-    durations."""
     total_cost: float = 0.0
     activation_cost: float = 0.0
     overtime_cost: float = 0.0
@@ -220,6 +201,7 @@ class KPIResult:
     deferral_cost: float = 0.0
     overtime_minutes: float = 0.0
     idle_minutes: float = 0.0
+    turnover_minutes: float = 0.0
     scheduled_count: int = 0
     deferred_count: int = 0
     blocks_opened: int = 0

--- a/src/data/capacity.py
+++ b/src/data/capacity.py
@@ -1,25 +1,7 @@
-"""Candidate block pool construction.
-
-Blocks are endogenous: the planner decides which ORs to open each day.
-The *candidate pool* — the set of blocks that *could* be opened — is
-determined from training-period weekday patterns, filtered by activation
-regularity, and given day-specific capacities that account for turnover.
-
-Design changes motivated by the data report:
-  - Template filtering: only include room-day pairs active in ≥ X% of
-    training weeks (default 25%).  The report shows 153/168 templates
-    activate ≥ 50%; filtering removes noise rooms.
-  - Day-specific capacity: Fridays get shorter capacity (report shows
-    Friday mean span 445 min vs ~490 for Mon–Thu).
-  - Turnover-aware effective capacity: C_eff = C_nominal - (mean_cases-1)*τ
-    is computed per template but applied uniformly via a capacity reduction.
-    The report shows mean turnover of 28.3 min.
-"""
-
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Tuple
+from typing import Dict, List, Set, Tuple
 
 import pandas as pd
 
@@ -27,151 +9,97 @@ from src.core.config import Config
 from src.core.types import BlockCalendar, CandidateBlock, Col
 
 logger = logging.getLogger(__name__)
-
-# Weekday index → name (for logging)
-_WEEKDAY_NAMES = {0: "Mon", 1: "Tue", 2: "Wed", 3: "Thu", 4: "Fri"}
-
-# Friday weekday index
 _FRIDAY = 4
 
 
-def build_candidate_pools(
-    df_train: pd.DataFrame, config: Config
-) -> Dict[int, List[str]]:
-    """Build weekday-level candidate room pools from training data,
-    filtered by historical activation regularity.
+def _aligned_complete_week_starts(df: pd.DataFrame) -> Set[pd.Timestamp]:
+    dt = pd.to_datetime(df[Col.ACTUAL_START], errors="coerce")
+    week_start = (dt - pd.to_timedelta(dt.dt.weekday, unit="D")).dt.normalize()
+    unique = sorted(week_start.dropna().unique())
+    if len(unique) <= 2:
+        return set(unique)
+    return set(unique[1:-1])
 
-    Parameters
-    ----------
-    df_train : DataFrame
-        Warm-up (training) data.  Must contain ``actual_start`` and
-        ``operating_room``.
-    config : Config
-        Provides ``capacity.min_activation_rate`` for template filtering.
 
-    Returns
-    -------
-    dict
-        Maps weekday index (0 = Monday, …, 4 = Friday) to a sorted list
-        of OR room names that were regularly active on that weekday.
-        Weekends (5, 6) are excluded.
-    """
+def build_candidate_pools(df_train: pd.DataFrame, config: Config) -> Dict[int, List[Tuple[str, str]]]:
     dt = pd.to_datetime(df_train[Col.ACTUAL_START], errors="coerce")
     df = df_train.assign(
         _weekday=dt.dt.weekday,
+        _site=df_train[Col.SITE].fillna("").astype(str).str.upper().str.strip(),
         _room=df_train[Col.OPERATING_ROOM],
         _week_start=(dt - pd.to_timedelta(dt.dt.weekday, unit="D")).dt.normalize(),
     )
     df = df.dropna(subset=["_weekday", "_room", "_week_start"])
+    df = df[df["_site"] != ""]
 
-    # Count total active training weeks (for activation rate denominator)
+    complete_weeks = _aligned_complete_week_starts(df)
+    df = df[df["_week_start"].isin(complete_weeks)]
     total_weeks = df["_week_start"].nunique()
     if total_weeks == 0:
-        logger.warning("No training weeks found — returning empty pools.")
         return {wd: [] for wd in range(5)}
 
-    min_rate = config.capacity.min_activation_rate
-    logger.info(
-        "Building candidate pools: %d training weeks, "
-        "min activation rate %.0f%%",
-        total_weeks, 100 * min_rate,
-    )
-
-    pools: Dict[int, List[str]] = {}
-    total_kept = 0
-    total_dropped = 0
-
-    for wd in range(5):  # Monday–Friday only
+    pools: Dict[int, List[Tuple[str, str]]] = {}
+    for wd in range(5):
         wd_data = df[df["_weekday"] == wd]
-
-        # For each room, count how many distinct weeks it was active
-        room_week_counts = (
-            wd_data.groupby("_room")["_week_start"]
-            .nunique()
-            .rename("active_weeks")
-        )
-        room_activation = room_week_counts / total_weeks
-
-        # Filter to rooms meeting the activation threshold
-        regular_rooms = sorted(
-            room_activation[room_activation >= min_rate].index.tolist()
-        )
-        dropped = len(room_activation) - len(regular_rooms)
-
-        pools[wd] = regular_rooms
-        total_kept += len(regular_rooms)
-        total_dropped += dropped
-
-    for wd, rooms in pools.items():
-        logger.info(
-            "Candidate pool %s: %d rooms (kept)  %s",
-            _WEEKDAY_NAMES.get(wd, str(wd)),
-            len(rooms),
-            rooms[:6],
-        )
-
-    logger.info(
-        "Total candidate blocks per full week: %d "
-        "(dropped %d low-activity templates)",
-        total_kept, total_dropped,
-    )
+        pair_counts = wd_data.groupby(["_site", "_room"])["_week_start"].nunique()
+        activation = pair_counts / total_weeks
+        regular = sorted([pair for pair, rate in activation.items() if rate >= config.capacity.min_activation_rate])
+        pools[wd] = regular
     return pools
 
 
+def classify_fixed_flex(
+    df_train_scoped: pd.DataFrame,
+    pools: Dict[int, List[Tuple[str, str]]],
+    threshold: float = 0.75,
+) -> Set[Tuple[int, str, str]]:
+    dt = pd.to_datetime(df_train_scoped[Col.ACTUAL_START], errors="coerce")
+    df = df_train_scoped.assign(
+        _weekday=dt.dt.weekday,
+        _site=df_train_scoped[Col.SITE].fillna("").astype(str).str.upper().str.strip(),
+        _room=df_train_scoped[Col.OPERATING_ROOM],
+        _week_start=(dt - pd.to_timedelta(dt.dt.weekday, unit="D")).dt.normalize(),
+    )
+    complete_weeks = _aligned_complete_week_starts(df)
+    df = df[df["_week_start"].isin(complete_weeks)]
+
+    fixed: Set[Tuple[int, str, str]] = set()
+    for wd, site_rooms in pools.items():
+        denom = len(complete_weeks)
+        if denom == 0:
+            continue
+        wd_data = df[df["_weekday"] == wd]
+        wk_counts = wd_data.groupby(["_site", "_room"])["_week_start"].nunique().to_dict()
+        for site, room in site_rooms:
+            rate = wk_counts.get((site, room), 0) / denom
+            if rate >= threshold:
+                fixed.add((wd, site, room))
+    return fixed
+
+
 def build_block_calendar(
-    pools: Dict[int, List[str]],
+    pools: Dict[int, List[Tuple[str, str]]],
     horizon_start: pd.Timestamp,
     config: Config,
+    fixed_templates: Set[Tuple[int, str, str]] | None = None,
 ) -> BlockCalendar:
-    """Build a :class:`BlockCalendar` for one planning horizon.
-
-    Maps each day of the horizon to its weekday, then looks up the
-    candidate rooms for that weekday from the pre-computed pools.
-
-    Day-specific capacity:
-      - Friday blocks use ``config.capacity.friday_capacity_minutes``
-      - All other weekdays use ``config.capacity.block_capacity_minutes``
-
-    Parameters
-    ----------
-    pools : dict
-        Weekday → room list, from :func:`build_candidate_pools`.
-    horizon_start : Timestamp
-        First day of the horizon.
-    config : Config
-        Provides capacity and activation cost settings.
-
-    Returns
-    -------
-    BlockCalendar
-        Contains one :class:`CandidateBlock` per (day, room) pair.
-    """
+    fixed_templates = fixed_templates or set()
     horizon_days = config.data.horizon_days
-    cap_default = config.capacity.block_capacity_minutes
-    cap_friday = config.capacity.friday_capacity_minutes
-    act_cost = config.capacity.activation_cost_per_block
     start = horizon_start.normalize()
-
     candidates: list[CandidateBlock] = []
+
     for d in range(horizon_days):
         cal_date = start + pd.Timedelta(days=d)
         weekday = cal_date.weekday()
-
-        # Day-specific capacity
-        cap = cap_friday if weekday == _FRIDAY else cap_default
-
-        rooms = pools.get(weekday, [])
-        for blk_idx, room in enumerate(rooms):
+        cap = config.capacity.friday_capacity_minutes if weekday == _FRIDAY else config.capacity.block_capacity_minutes
+        for site, room in pools.get(weekday, []):
             candidates.append(CandidateBlock(
                 day_index=d,
-                block_index=blk_idx,
+                site=site,
                 room=room,
                 capacity_minutes=cap,
-                activation_cost=act_cost,
+                activation_cost=config.capacity.activation_cost_per_block,
+                is_fixed=(weekday, site, room) in fixed_templates,
             ))
 
-    logger.debug(
-        "Block calendar for %s: %d candidate blocks across %d days",
-        start.date(), len(candidates), horizon_days,
-    )
     return BlockCalendar(candidates=candidates)

--- a/src/data/eligibility.py
+++ b/src/data/eligibility.py
@@ -1,28 +1,8 @@
-"""Eligibility set construction for case-to-block assignment.
-
-Builds the data structures needed to enforce B_ti ⊆ B_t (paper Section 3.5)
-from training-period observations.  Three layers of filtering:
-
-  1. Service → room compatibility (hard):
-     A case of service s can only be assigned to block ℓ if room(ℓ)
-     historically served service s.
-
-  2. Site compatibility (hard):
-     A case can only be assigned to a block at the same site.
-
-  3. Surgeon → template preference (soft):
-     A surgeon's cases are preferentially assigned to their top-K
-     historical room-day templates.  Falls back to service-level
-     eligibility if the surgeon has insufficient history.
-
-These are computed once on training data and reused for every test week.
-"""
-
 from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from typing import Dict, FrozenSet, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import pandas as pd
 
@@ -32,27 +12,9 @@ from src.core.types import CandidateBlock, Col
 logger = logging.getLogger(__name__)
 
 
-# ─── Data structures ─────────────────────────────────────────────────────────
-
 class EligibilityMaps:
-    """Pre-computed eligibility data from the training period.
-
-    Attributes
-    ----------
-    service_rooms : dict[str, set[str]]
-        Maps surgical service → set of room names that historically
-        served that service.
-    room_site : dict[str, str]
-        Maps room name → site (e.g., "TWH", "TGH", "PMH").
-        Rooms with unknown site are mapped to "UNKNOWN".
-    surgeon_templates : dict[str, list[tuple[str, int]]]
-        Maps surgeon_code → list of (room, weekday) pairs, ordered
-        by descending frequency.  Only populated for surgeons with
-        sufficient case history.
-    """
-
     def __init__(self) -> None:
-        self.service_rooms: Dict[str, Set[str]] = defaultdict(set)
+        self.service_rooms: Dict[str, Set[Tuple[str, str]]] = defaultdict(set)
         self.room_site: Dict[str, str] = {}
         self.surgeon_templates: Dict[str, List[Tuple[str, int]]] = {}
 
@@ -62,48 +24,32 @@ class EligibilityMaps:
         surgeon_code: str,
         operating_room: str,
         config: Config,
-    ) -> Optional[Set[str]]:
-        """Return the set of room names a case is eligible for.
-
-        Returns None if no filtering should be applied (i.e., the case
-        is eligible for all candidate blocks).  This lets the solver
-        skip constraint generation for unrestricted cases.
-        """
+        case_site: str = "",
+    ) -> Optional[Set[Tuple[str, str]]]:
         elig_cfg = config.eligibility
-        allowed: Optional[Set[str]] = None
+        allowed: Optional[Set[Tuple[str, str]]] = None
 
-        # Layer 1: service → room
         if elig_cfg.use_service_room_filter and service in self.service_rooms:
             allowed = set(self.service_rooms[service])
 
-        # Layer 2: site filter
-        if elig_cfg.use_site_filter and operating_room in self.room_site:
-            case_site = self.room_site[operating_room]
-            site_rooms = {
-                r for r, s in self.room_site.items() if s == case_site
-            }
-            if allowed is not None:
-                allowed &= site_rooms
-            else:
-                allowed = site_rooms
+        if elig_cfg.use_site_filter:
+            site = case_site or self.room_site.get(operating_room, "")
+            if site:
+                site_pairs = {(s, r) for r, s in self.room_site.items() if s == site}
+                if allowed is None:
+                    allowed = site_pairs
+                else:
+                    allowed &= site_pairs
 
-        # Layer 3: surgeon preference (narrows further, with fallback)
-        if (
-            elig_cfg.use_surgeon_preference
-            and surgeon_code in self.surgeon_templates
-        ):
+        if elig_cfg.use_surgeon_preference and surgeon_code in self.surgeon_templates:
             top_k = elig_cfg.surgeon_top_k_templates
-            pref_rooms = {
-                room
-                for room, _ in self.surgeon_templates[surgeon_code][:top_k]
-            }
-            if allowed is not None:
-                narrowed = allowed & pref_rooms
-                # Fallback: if intersection is empty, keep service-level
+            pref = {(self.room_site.get(room, ""), room) for room, _ in self.surgeon_templates[surgeon_code][:top_k]}
+            if allowed is None:
+                allowed = pref
+            else:
+                narrowed = allowed & pref
                 if narrowed:
                     allowed = narrowed
-            else:
-                allowed = pref_rooms
 
         return allowed
 
@@ -114,103 +60,55 @@ class EligibilityMaps:
         surgeon_code: str,
         operating_room: str,
         config: Config,
+        case_site: str = "",
     ) -> bool:
-        """Check whether a specific block is eligible for a case."""
-        allowed = self.eligible_rooms_for_case(
-            service, surgeon_code, operating_room, config
-        )
+        allowed = self.eligible_rooms_for_case(service, surgeon_code, operating_room, config, case_site)
         if allowed is None:
             return True
-        return block.room in allowed
+        return (block.site, block.room) in allowed
 
 
-def build_eligibility_maps(
-    df_train: pd.DataFrame,
-    config: Config,
-) -> EligibilityMaps:
-    """Build eligibility mappings from training data.
-
-    Parameters
-    ----------
-    df_train : DataFrame
-        Warm-up (training) data with canonical column names.
-    config : Config
-        Provides eligibility settings (min cases for surgeon prefs, etc.).
-
-    Returns
-    -------
-    EligibilityMaps
-    """
+def build_eligibility_maps(df_train: pd.DataFrame, config: Config) -> EligibilityMaps:
     maps = EligibilityMaps()
 
-    # ── Service → room mapping ───────────────────────────────────────────
-    if Col.CASE_SERVICE in df_train.columns:
-        svc_room = (
-            df_train.dropna(subset=[Col.CASE_SERVICE, Col.OPERATING_ROOM])
-            .groupby(Col.CASE_SERVICE)[Col.OPERATING_ROOM]
-            .apply(lambda x: set(x.unique()))
-        )
-        for svc, rooms in svc_room.items():
-            maps.service_rooms[svc] = rooms
-        logger.info(
-            "Service→room map: %d services, median %d rooms/service",
-            len(maps.service_rooms),
-            int(pd.Series([len(v) for v in maps.service_rooms.values()]).median()),
-        )
+    work = df_train.copy()
+    dt = pd.to_datetime(work[Col.ACTUAL_START], errors="coerce")
+    iso = dt.dt.isocalendar()
+    work["_iso_year"] = iso.year.astype(int)
+    work["_iso_week"] = iso.week.astype(int)
 
-    # ── Room → site mapping ──────────────────────────────────────────────
-    # The UHN data has a "Site" column on the raw data.  After the loader
-    # normalises column names, it may appear as "site".  We try both.
-    site_col = None
-    for candidate in ["site", "Site"]:
-        if candidate in df_train.columns:
-            site_col = candidate
-            break
+    # Room->site map first
+    room_site = (
+        work.dropna(subset=[Col.OPERATING_ROOM, Col.SITE])
+        .assign(_site=work[Col.SITE].fillna("").astype(str).str.upper().str.strip())
+    )
+    room_site = room_site[room_site["_site"] != ""]
+    maps.room_site = room_site.groupby(Col.OPERATING_ROOM)["_site"].agg(lambda x: x.mode().iloc[0]).to_dict()
 
-    if site_col is not None:
-        room_site = (
-            df_train.dropna(subset=[Col.OPERATING_ROOM, site_col])
-            .groupby(Col.OPERATING_ROOM)[site_col]
-            .agg(lambda x: x.mode().iloc[0] if len(x.mode()) > 0 else "UNKNOWN")
-        )
-        maps.room_site = room_site.to_dict()
-        n_sites = len(set(maps.room_site.values()) - {"UNKNOWN"})
-        logger.info("Room→site map: %d rooms across %d sites",
-                     len(maps.room_site), n_sites)
-    else:
-        logger.info("No site column found — site filtering disabled.")
+    min_weeks = config.capacity.eligibility_min_weeks
+    svc_data = work.dropna(subset=[Col.CASE_SERVICE, Col.OPERATING_ROOM])
+    svc_data = svc_data.assign(_site=svc_data[Col.SITE].fillna("").astype(str).str.upper().str.strip())
+    svc_data = svc_data[svc_data["_site"] != ""]
 
-    # ── Surgeon → template preferences ───────────────────────────────────
+    grouped = svc_data.groupby([Col.CASE_SERVICE, "_site", Col.OPERATING_ROOM]).apply(
+        lambda g: len(set(zip(g["_iso_year"], g["_iso_week"])))
+    )
+    if len(grouped) > 0:
+        for (svc, site, room), n_weeks in grouped.items():
+            if n_weeks >= min_weeks:
+                maps.service_rooms[svc].add((site, room))
+
     elig_cfg = config.eligibility
     if elig_cfg.use_surgeon_preference:
-        dt = pd.to_datetime(df_train[Col.ACTUAL_START], errors="coerce")
-        df_work = df_train.assign(
-            _weekday=dt.dt.weekday,
-            _room=df_train[Col.OPERATING_ROOM],
-        ).dropna(subset=["_weekday", "_room", Col.SURGEON_CODE])
-
-        # Only build preferences for surgeons with enough history
+        df_work = work.assign(_weekday=dt.dt.weekday, _room=work[Col.OPERATING_ROOM]).dropna(
+            subset=["_weekday", "_room", Col.SURGEON_CODE]
+        )
         surg_counts = df_work[Col.SURGEON_CODE].value_counts()
-        eligible_surgeons = surg_counts[
-            surg_counts >= elig_cfg.surgeon_min_cases_for_preference
-        ].index
-
+        eligible_surgeons = surg_counts[surg_counts >= elig_cfg.surgeon_min_cases_for_preference].index
         for surg in eligible_surgeons:
             sub = df_work[df_work[Col.SURGEON_CODE] == surg]
-            template_counts = (
-                sub.groupby(["_room", "_weekday"]).size()
-                .sort_values(ascending=False)
-            )
-            templates = [
-                (room, int(wd))
-                for (room, wd), _ in template_counts.items()
-            ]
-            maps.surgeon_templates[surg] = templates
+            template_counts = sub.groupby(["_room", "_weekday"]).size().sort_values(ascending=False)
+            maps.surgeon_templates[surg] = [(room, int(wd)) for (room, wd), _ in template_counts.items()]
 
-        logger.info(
-            "Surgeon templates: %d surgeons with ≥ %d cases",
-            len(maps.surgeon_templates),
-            elig_cfg.surgeon_min_cases_for_preference,
-        )
-
+    logger.info("Eligibility map built: %d services", len(maps.service_rooms))
     return maps

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -1,15 +1,9 @@
-"""Data loading and cleaning for the UHN surgical dataset.
-
-Reads the raw Excel file, normalises column names, filters to elective
-completed OR cases, computes durations, recodes rare categories, and returns
-a tidy DataFrame sorted by ``actual_start``.
-"""
+"""Data loading and cleaning for the UHN surgical dataset."""
 
 from __future__ import annotations
 
 import logging
 import sys
-from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -19,7 +13,6 @@ from src.core.types import Col, Domain
 
 logger = logging.getLogger(__name__)
 
-# Columns we ask the Excel reader to load (original header names).
 _EXCEL_COLUMNS = [
     "Patient_Type", "Case_Service", "Main_Procedure", "Main_Procedure_Id",
     "Operating_Room", "Site", "Booked Time (Minutes)",
@@ -32,19 +25,8 @@ _EXCEL_COLUMNS = [
 
 
 def load_data(config: Config) -> pd.DataFrame:
-    """Read the raw Excel file and return a cleaned elective-surgery DataFrame.
-
-    The returned DataFrame uses canonical snake_case column names defined in
-    :class:`Col` and is sorted by ``actual_start``.
-
-    Raises
-    ------
-    SystemExit
-        If the Excel file cannot be found or read.
-    """
     path = config.data.excel_file_path
     logger.info("Loading data from %s", path)
-
     try:
         df = pd.read_excel(path, usecols=_EXCEL_COLUMNS)
     except FileNotFoundError:
@@ -52,7 +34,6 @@ def load_data(config: Config) -> pd.DataFrame:
     except Exception as exc:
         sys.exit(f"Error reading data file: {exc}")
 
-    # ── Normalise column names to snake_case ─────────────────────────────
     df.columns = (
         df.columns.str.strip()
         .str.lower()
@@ -60,70 +41,106 @@ def load_data(config: Config) -> pd.DataFrame:
         .str.replace(r"^_|_$", "", regex=True)
     )
 
-    # ── Row-level filters ────────────────────────────────────────────────
     df = df[df[Col.ACTUAL_START_DATE].notna()]
 
-    # Keep only actual OR rooms (prefix "OR"), exclude emergency-designated rooms
     room_upper = df[Col.OPERATING_ROOM].fillna("").astype(str).str.upper()
     is_or = room_upper.str.startswith(Domain.OR_ROOM_PREFIX)
-    is_emergency_room = room_upper.isin(
-        [r.upper() for r in Domain.EMERGENCY_ROOMS])
+    is_emergency_room = room_upper.isin([r.upper() for r in Domain.EMERGENCY_ROOMS])
     df = df[is_or & ~is_emergency_room]
-
-    # Exclude emergency patients
     df = df[df[Col.PATIENT_TYPE] != Domain.EMERGENCY_PATIENT]
 
-    # ── Parse timestamps ─────────────────────────────────────────────────
-    df[Col.ACTUAL_START] = _combine_date_time(df, Col.ACTUAL_START_DATE,
-                                               Col.ACTUAL_START_TIME)
-    df[Col.ACTUAL_STOP] = _combine_date_time(df, Col.ACTUAL_STOP_DATE,
-                                              Col.ACTUAL_STOP_TIME)
-    df[Col.ENTER_ROOM] = _combine_date_time(df, Col.ENTER_ROOM_DATE,
-                                             Col.ENTER_ROOM_TIME)
-    df[Col.LEAVE_ROOM] = _combine_date_time(df, Col.LEAVE_ROOM_DATE,
-                                             Col.LEAVE_ROOM_TIME)
+    df[Col.ACTUAL_START] = _combine_date_time(df, Col.ACTUAL_START_DATE, Col.ACTUAL_START_TIME)
+    df[Col.ACTUAL_STOP] = _combine_date_time(df, Col.ACTUAL_STOP_DATE, Col.ACTUAL_STOP_TIME)
+    df[Col.ENTER_ROOM] = _combine_date_time(df, Col.ENTER_ROOM_DATE, Col.ENTER_ROOM_TIME)
+    df[Col.LEAVE_ROOM] = _combine_date_time(df, Col.LEAVE_ROOM_DATE, Col.LEAVE_ROOM_TIME)
 
-    # Drop the raw date / time string columns
-    _date_time_cols = [
+    df = df.drop(columns=[
         Col.ACTUAL_START_DATE, Col.ACTUAL_START_TIME,
         Col.ACTUAL_STOP_DATE, Col.ACTUAL_STOP_TIME,
         Col.ENTER_ROOM_DATE, Col.ENTER_ROOM_TIME,
         Col.LEAVE_ROOM_DATE, Col.LEAVE_ROOM_TIME,
-    ]
-    df = df.drop(columns=[c for c in _date_time_cols if c in df.columns])
+    ], errors="ignore")
 
-    # ── Compute durations ────────────────────────────────────────────────
-    df[Col.PROCEDURE_DURATION] = (
-        (df[Col.ACTUAL_STOP] - df[Col.ACTUAL_START])
-        .dt.total_seconds() / 60.0
+    df[Col.SURGICAL_DURATION] = ((df[Col.ACTUAL_STOP] - df[Col.ACTUAL_START]).dt.total_seconds() / 60.0)
+    df[Col.ROOM_DURATION] = ((df[Col.LEAVE_ROOM] - df[Col.ENTER_ROOM]).dt.total_seconds() / 60.0)
+
+    has_all_four = (
+        df[Col.ENTER_ROOM].notna()
+        & df[Col.ACTUAL_START].notna()
+        & df[Col.ACTUAL_STOP].notna()
+        & df[Col.LEAVE_ROOM].notna()
     )
+    order_ok = (
+        (df[Col.ENTER_ROOM] <= df[Col.ACTUAL_START])
+        & (df[Col.ACTUAL_START] <= df[Col.ACTUAL_STOP])
+        & (df[Col.ACTUAL_STOP] <= df[Col.LEAVE_ROOM])
+    )
+    severe = has_all_four & (df[Col.LEAVE_ROOM] < df[Col.ENTER_ROOM])
+    df = df[~severe].copy()
+    has_all_four = has_all_four.loc[df.index]
+    order_ok = order_ok.loc[df.index]
+
+    mild_violation = has_all_four & ~order_ok
+
+    room_time_valid = df[Col.ROOM_DURATION].notna() & (df[Col.ROOM_DURATION] > 0)
+    overhead_capped = room_time_valid & ((df[Col.ROOM_DURATION] - df[Col.SURGICAL_DURATION]) > 300)
+
+    df[Col.TIMESTAMP_VIOLATION] = mild_violation
+    df[Col.OVERHEAD_CAPPED] = overhead_capped
+    df[Col.USED_ROOM_TIME] = room_time_valid & ~mild_violation & ~overhead_capped
+    df[Col.FELL_BACK_SURGICAL] = ~df[Col.USED_ROOM_TIME]
+
+    df[Col.PROCEDURE_DURATION] = np.where(
+        df[Col.USED_ROOM_TIME],
+        df[Col.ROOM_DURATION],
+        df[Col.SURGICAL_DURATION],
+    )
+
     df[Col.PREPARATION_DURATION] = (
-        (df[Col.ACTUAL_START] - df[Col.ENTER_ROOM])
-        .dt.total_seconds().clip(lower=0) / 60.0
+        (df[Col.ACTUAL_START] - df[Col.ENTER_ROOM]).dt.total_seconds().clip(lower=0) / 60.0
     )
 
-    # Drop cases with missing or non-positive procedure durations
-    df = df[df[Col.PROCEDURE_DURATION] >= Domain.MIN_PROCEDURE_DURATION]
+    df = df[df[Col.PROCEDURE_DURATION] >= Domain.MIN_PROCEDURE_DURATION].copy()
 
-    # ── Recode rare categories ───────────────────────────────────────────
-    df[Col.PROCEDURE_ID] = _recode_rare(
-        df[Col.PROCEDURE_ID], config.data.min_samples_procedure)
-    df[Col.SURGEON_CODE] = _recode_rare(
-        df[Col.SURGEON_CODE], config.data.min_samples_surgeon)
-    df[Col.CASE_SERVICE] = _recode_rare(
-        df[Col.CASE_SERVICE], config.data.min_samples_service)
+    df[Col.SITE] = df.get(Col.SITE, "").fillna("").astype(str).str.strip().str.upper()
+    room_site_nuniq = (
+        df[df[Col.SITE] != ""]
+        .groupby(Col.OPERATING_ROOM)[Col.SITE]
+        .nunique()
+    )
+    unambiguous_rooms = set(room_site_nuniq[room_site_nuniq == 1].index)
+    room_site_lookup = (
+        df[(df[Col.OPERATING_ROOM].isin(unambiguous_rooms)) & (df[Col.SITE] != "")]
+        .groupby(Col.OPERATING_ROOM)[Col.SITE]
+        .first()
+        .to_dict()
+    )
+    missing_site = df[Col.SITE] == ""
+    df.loc[missing_site, Col.SITE] = df.loc[missing_site, Col.OPERATING_ROOM].map(room_site_lookup).fillna("")
 
-    # ── Calendar features ────────────────────────────────────────────────
+    df[Col.PROCEDURE_ID] = _recode_rare(df[Col.PROCEDURE_ID], config.data.min_samples_procedure)
+    df[Col.SURGEON_CODE] = _recode_rare(df[Col.SURGEON_CODE], config.data.min_samples_surgeon)
+    df[Col.CASE_SERVICE] = _recode_rare(df[Col.CASE_SERVICE], config.data.min_samples_service)
+
     df = add_time_features(df)
-
-    # ── Final sort and reset ─────────────────────────────────────────────
     df = df.sort_values(Col.ACTUAL_START).reset_index(drop=True)
+    df[Col.CASE_UID] = range(len(df))
+
+    logger.info(
+        "Quality: used_room_time=%d fallback=%d mild_timestamp_violations=%d overhead_capped=%d missing_site=%d",
+        int(df[Col.USED_ROOM_TIME].sum()),
+        int(df[Col.FELL_BACK_SURGICAL].sum()),
+        int(df[Col.TIMESTAMP_VIOLATION].sum()),
+        int(df[Col.OVERHEAD_CAPPED].sum()),
+        int((df[Col.SITE] == "").sum()),
+    )
+    site_counts = df[Col.SITE].value_counts(dropna=False).to_dict()
+    logger.info("Cases by site: %s", site_counts)
     logger.info("Loaded %d elective cases after cleaning.", len(df))
     return df
 
 
 def add_time_features(df: pd.DataFrame) -> pd.DataFrame:
-    """Add ``week_of_year``, ``month``, ``year`` columns from ``actual_start``."""
     dt = pd.to_datetime(df[Col.ACTUAL_START], errors="coerce")
     df[Col.WEEK_OF_YEAR] = dt.dt.isocalendar().week.astype(int)
     df[Col.MONTH] = dt.dt.month.astype(int)
@@ -131,18 +148,11 @@ def add_time_features(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-# ── Private helpers ──────────────────────────────────────────────────────────
-
-def _combine_date_time(df: pd.DataFrame, date_col: str,
-                       time_col: str) -> pd.Series:
-    """Merge a date column and a time-string column into a datetime Series."""
+def _combine_date_time(df: pd.DataFrame, date_col: str, time_col: str) -> pd.Series:
     if date_col not in df.columns or time_col not in df.columns:
         return pd.Series(pd.NaT, index=df.index)
-
     dates = pd.to_datetime(df[date_col], errors="coerce")
-    times = df[time_col].fillna("00:00:00").astype(str).str.strip()
-    times = times.str.split(".").str[0]           # drop fractional seconds
-
+    times = df[time_col].fillna("00:00:00").astype(str).str.strip().str.split(".").str[0]
     valid = dates.notna()
     result = pd.Series(pd.NaT, index=df.index, dtype="datetime64[ns]")
     if valid.any():
@@ -154,7 +164,6 @@ def _combine_date_time(df: pd.DataFrame, date_col: str,
 
 
 def _recode_rare(series: pd.Series, threshold: int) -> pd.Series:
-    """Replace values that appear fewer than *threshold* times with 'Other'."""
     series = series.astype(object)
     counts = series.value_counts()
     rare = counts[counts < threshold].index

--- a/src/data/scope.py
+++ b/src/data/scope.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Tuple
+
+import pandas as pd
+
+from src.core.config import Config
+from src.core.types import Col
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ScopeSummary:
+    total_before: int
+    excluded_weekend: int
+    excluded_site: int
+    excluded_missing_site: int
+    total_after: int
+
+
+def apply_experiment_scope(df: pd.DataFrame, config: Config) -> Tuple[pd.DataFrame, ScopeSummary]:
+    dt = pd.to_datetime(df[Col.ACTUAL_START], errors="coerce")
+    weekdays = set(config.scope.planning_weekdays)
+    sites = set(config.scope.planning_sites)
+
+    is_weekday = dt.dt.weekday.isin(weekdays)
+    site_vals = df[Col.SITE].fillna("").astype(str).str.upper().str.strip()
+    missing_site = site_vals == ""
+    in_site = site_vals.isin(sites)
+
+    keep = is_weekday & in_site & ~missing_site
+    scoped = df[keep].copy()
+
+    summary = ScopeSummary(
+        total_before=len(df),
+        excluded_weekend=int((~is_weekday).sum()),
+        excluded_site=int((is_weekday & ~in_site & ~missing_site).sum()),
+        excluded_missing_site=int((is_weekday & missing_site).sum()),
+        total_after=len(scoped),
+    )
+    logger.info("Scope summary: %s", summary)
+    return scoped, summary

--- a/src/experiments/runner.py
+++ b/src/experiments/runner.py
@@ -1,17 +1,9 @@
-"""Rolling-horizon out-of-sample experiment runner.
-
-Loads data, splits into warm-up and pool, builds candidate block pools
-from training data, fits every registered method on the warm-up set,
-then evaluates each method on successive weekly horizons drawn from the
-pool.  Results are collected into a single table and optionally saved
-to disk.
-"""
-
 from __future__ import annotations
 
 import json
 import logging
 import time
+from dataclasses import asdict
 from datetime import timedelta
 from pathlib import Path
 from typing import Any, Dict, List
@@ -19,35 +11,46 @@ from typing import Any, Dict, List
 import pandas as pd
 
 from src.core.config import Config
-from src.core.types import Col, KPIResult
+from src.core.types import KPIResult
+from src.data.capacity import build_candidate_pools, classify_fixed_flex
+from src.data.eligibility import build_eligibility_maps
 from src.data.loader import load_data
+from src.data.scope import apply_experiment_scope
 from src.data.splits import split_warmup_pool
-from src.data.capacity import build_candidate_pools
-from src.methods.base import Method
 from src.methods.registry import MethodRegistry
+from src.planning.audit import audit_surgeon_feasibility
 from src.planning.evaluation import evaluate
 from src.planning.instance import build_weekly_instance
+from src.validation import validate_week
 
 logger = logging.getLogger(__name__)
 
 
-# ─── Result collection ───────────────────────────────────────────────────────
-
 def _empty_kpi_row(method_name: str, week: int) -> Dict[str, Any]:
     return {
-        "method": method_name, "week": week,
-        "total_cost": None, "activation_cost": None,
-        "overtime_cost": None, "idle_cost": None,
-        "deferral_cost": None, "overtime_min": None, "idle_min": None,
-        "scheduled": None, "deferred": None, "blocks_opened": None,
-        "planned_obj": None, "solve_time": None,
+        "method": method_name,
+        "week": week,
+        "total_cost": None,
+        "activation_cost": None,
+        "overtime_cost": None,
+        "idle_cost": None,
+        "deferral_cost": None,
+        "overtime_min": None,
+        "idle_min": None,
+        "scheduled": None,
+        "deferred": None,
+        "blocks_opened": None,
+        "turnover_minutes": None,
+        "n_fixed_blocks": None,
+        "n_flex_blocks": None,
+        "n_forced_defer": None,
+        "n_adaptive_k2": None,
+        "planned_obj": None,
+        "solve_time": None,
     }
 
 
-def _kpi_to_row(
-    method_name: str, week: int,
-    kpi: KPIResult, planned_obj: float | None, solve_time: float,
-) -> Dict[str, Any]:
+def _kpi_to_row(method_name: str, week: int, kpi: KPIResult, planned_obj: float | None, solve_time: float, n_fixed: int, n_flex: int, n_forced_defer: int, n_adaptive_k2: int) -> Dict[str, Any]:
     return {
         "method": method_name,
         "week": week,
@@ -61,196 +64,98 @@ def _kpi_to_row(
         "scheduled": kpi.scheduled_count,
         "deferred": kpi.deferred_count,
         "blocks_opened": kpi.blocks_opened,
+        "turnover_minutes": kpi.turnover_minutes,
+        "n_fixed_blocks": n_fixed,
+        "n_flex_blocks": n_flex,
+        "n_forced_defer": n_forced_defer,
+        "n_adaptive_k2": n_adaptive_k2,
         "planned_obj": planned_obj,
         "solve_time": solve_time,
     }
 
 
-# ─── Main runner ─────────────────────────────────────────────────────────────
-
-def run_experiment(
-    registry: MethodRegistry,
-    config: Config,
-    output_dir: str | Path | None = None,
-) -> pd.DataFrame:
-    """Execute the full rolling-horizon experiment.
-
-    Parameters
-    ----------
-    registry : MethodRegistry
-        The set of methods to compare.
-    config : Config
-        Experiment configuration.
-    output_dir : path-like, optional
-        If given, write per-horizon CSV and aggregate summary JSON here.
-
-    Returns
-    -------
-    DataFrame
-        One row per (method, week) with all KPI columns.
-    """
-    # ── Load and split ───────────────────────────────────────────────────
+def run_experiment(registry: MethodRegistry, config: Config, output_dir: str | Path | None = None) -> pd.DataFrame:
     df = load_data(config)
     df_warmup, df_pool, pool_start = split_warmup_pool(df, config)
 
-    if df_pool.empty:
-        logger.error("Scheduling pool is empty — nothing to evaluate.")
-        return pd.DataFrame()
+    elig_maps = build_eligibility_maps(df_warmup, config)
+    eligibility = elig_maps.service_rooms
 
-    # ── Build candidate block pools from training data (once) ────────────
-    candidate_pools = build_candidate_pools(df_warmup, config)
+    df_warmup_scoped, warmup_scope_summary = apply_experiment_scope(df_warmup, config)
+    candidate_pools = build_candidate_pools(df_warmup_scoped, config)
+    fixed_templates = classify_fixed_flex(df_warmup_scoped, candidate_pools, config.capacity.fixed_block_threshold)
 
-    # ── Fit every method on warm-up data ─────────────────────────────────
-    logger.info("Fitting %d methods on warm-up data (%d cases).",
-                len(registry), len(df_warmup))
+    df_pool_scoped, scope_summary = apply_experiment_scope(df_pool, config)
+
     for method in registry:
         t0 = time.perf_counter()
         method.fit(df_warmup)
-        elapsed = time.perf_counter() - t0
-        logger.info("  %-20s fitted in %.1fs", method.name, elapsed)
+        logger.info("  %-20s fitted in %.1fs", method.name, time.perf_counter() - t0)
 
-    # ── Horizon loop ─────────────────────────────────────────────────────
     num_horizons = config.data.num_horizons
-    horizon_days = config.data.horizon_days
     current_start = pool_start
     rows: List[Dict[str, Any]] = []
-
-    logger.info("Running %d horizons × %d methods.", num_horizons, len(registry))
-    print()
-    _print_header(registry)
+    method_rows: Dict[str, List[Dict[str, Any]]] = {m.name: [] for m in registry}
 
     for h in range(num_horizons):
-        instance = build_weekly_instance(
-            df_pool, current_start, h, config, candidate_pools)
-
+        instance = build_weekly_instance(df_pool_scoped, current_start, h, config, candidate_pools, eligibility, fixed_templates)
         if instance.num_cases == 0:
-            logger.info("Week %d: no cases — stopping early.", h)
             break
-
-        week_results: Dict[str, str] = {}
 
         for method in registry:
             try:
                 t0 = time.perf_counter()
                 schedule = method.plan(instance)
                 solve_time = time.perf_counter() - t0
-
-                kpi = evaluate(instance, schedule, config.costs)
-
-                rows.append(_kpi_to_row(
-                    method.name, h, kpi,
-                    schedule.objective_value, solve_time,
-                ))
-                week_results[method.name] = kpi.summary_line()
-
+                kpi = evaluate(instance, schedule, config.costs, turnover=config.capacity.turnover_minutes)
+                audit = audit_surgeon_feasibility(instance, schedule)
+                n_forced = sum(1 for i in range(instance.num_cases) if len(instance.case_eligible_blocks.get(i, [])) == 0)
+                row = _kpi_to_row(
+                    method.name,
+                    h,
+                    kpi,
+                    schedule.objective_value,
+                    solve_time,
+                    len(instance.calendar.fixed_blocks),
+                    len(instance.calendar.flex_blocks),
+                    n_forced,
+                    audit.adaptive_k2_count,
+                )
+                rows.append(row)
+                method_rows[method.name].append(row)
+                validate_week(instance, schedule, config, method.name)
             except Exception:
                 logger.exception("Method %s failed on week %d.", method.name, h)
                 rows.append(_empty_kpi_row(method.name, h))
-                week_results[method.name] = "FAILED"
 
-        _print_week(h, instance, week_results, registry)
-        current_start += timedelta(days=horizon_days)
+        current_start += timedelta(days=config.scope.stride_days)
 
-    # ── Assemble results ─────────────────────────────────────────────────
     results_df = pd.DataFrame(rows)
-    if results_df.empty:
-        logger.warning("No results produced.")
-        return results_df
 
-    print()
-    _print_summary(results_df, registry)
-
-    # ── Save outputs ─────────────────────────────────────────────────────
     if output_dir is not None:
         out = Path(output_dir)
         out.mkdir(parents=True, exist_ok=True)
+        (out / "config_snapshot.json").write_text(json.dumps(asdict(config), indent=2, default=str))
+        (out / "scope_summary.json").write_text(json.dumps({"warmup": asdict(warmup_scope_summary), "pool": asdict(scope_summary)}, indent=2))
+        (out / "eligibility_summary.json").write_text(json.dumps({
+            "n_services": len(eligibility),
+            "mean_site_room_pairs_per_service": (sum(len(v) for v in eligibility.values()) / max(len(eligibility), 1)),
+        }, indent=2))
+        (out / "fixed_flex_summary.json").write_text(json.dumps({
+            "fixed_templates": len(fixed_templates),
+            "candidate_pool_sizes": {str(k): len(v) for k, v in candidate_pools.items()},
+        }, indent=2))
+        results_df.to_csv(out / "horizon_results.csv", index=False)
 
-        csv_path = out / "horizon_results.csv"
-        results_df.to_csv(csv_path, index=False)
-        logger.info("Per-horizon results saved to %s", csv_path)
-
-        summary = _aggregate(results_df, registry)
-        json_path = out / "aggregate_summary.json"
-        json_path.write_text(json.dumps(summary, indent=2))
-        logger.info("Aggregate summary saved to %s", json_path)
-
+    _validate_oracle_leq_booked(method_rows)
     return results_df
 
 
-# ─── Aggregation ─────────────────────────────────────────────────────────────
-
-def _aggregate(df: pd.DataFrame, registry: MethodRegistry) -> Dict[str, Any]:
-    """Compute mean and median KPIs per method."""
-    agg: Dict[str, Any] = {}
-    for method in registry:
-        sub = df[df["method"] == method.name]
-        if sub.empty:
+def _validate_oracle_leq_booked(method_rows: Dict[str, List[Dict[str, Any]]]) -> None:
+    if "Oracle" not in method_rows or "Booked" not in method_rows:
+        return
+    for b, o in zip(method_rows["Booked"], method_rows["Oracle"]):
+        if b.get("total_cost") is None or o.get("total_cost") is None:
             continue
-        entry: Dict[str, float | None] = {}
-        for col in ["total_cost", "activation_cost", "overtime_min",
-                     "idle_min", "scheduled", "deferred",
-                     "blocks_opened", "solve_time"]:
-            vals = sub[col].dropna()
-            entry[f"mean_{col}"] = float(vals.mean()) if len(vals) > 0 else None
-            entry[f"median_{col}"] = float(vals.median()) if len(vals) > 0 else None
-        agg[method.name] = entry
-    return agg
-
-
-# ─── Console output ──────────────────────────────────────────────────────────
-
-def _print_header(registry: MethodRegistry) -> None:
-    names = registry.names
-    header = f"{'Wk':>4s}  {'N':>4s}  {'Cand':>4s}"
-    for name in names:
-        header += f"  │ {name:>10s}: {'cost':>8s} {'blks':>4s} {'OT':>5s} {'sch':>3s}"
-    print(header)
-    print("─" * len(header))
-
-
-def _print_week(
-    h: int,
-    instance,
-    results: Dict[str, str],
-    registry: MethodRegistry,
-) -> None:
-    line = (f"{h:4d}  {instance.num_cases:4d}  "
-            f"{instance.calendar.total_candidates:4d}")
-    for method in registry:
-        txt = results.get(method.name, "N/A")
-        line += f"  │ {txt}"
-    print(line)
-
-
-def _print_summary(df: pd.DataFrame, registry: MethodRegistry) -> None:
-    print()
-    print("=" * 80)
-    print("  AGGREGATE RESULTS (mean ± std over horizons)")
-    print("=" * 80)
-    fmt = "  {:<12s}  {:>12s}  {:>10s}  {:>10s}  {:>10s}  {:>5s}  {:>5s}  {:>5s}"
-    print(fmt.format("Method", "Total Cost", "Activation", "OT (min)",
-                      "Idle (min)", "Sched", "Def", "Blks"))
-    print("  " + "─" * 76)
-    for method in registry:
-        sub = df[df["method"] == method.name]
-        if sub.empty:
-            print(f"  {method.name:<12s}  {'no data':>12s}")
-            continue
-
-        def _fmt(col: str) -> str:
-            vals = sub[col].dropna()
-            if vals.empty:
-                return "N/A"
-            return f"{vals.mean():,.0f}±{vals.std():,.0f}"
-
-        print(fmt.format(
-            method.name,
-            _fmt("total_cost"),
-            _fmt("activation_cost"),
-            _fmt("overtime_min"),
-            _fmt("idle_min"),
-            _fmt("scheduled"),
-            _fmt("deferred"),
-            _fmt("blocks_opened"),
-        ))
-    print("=" * 80)
+        if o["total_cost"] > b["total_cost"]:
+            logger.warning("Oracle > Booked on week %s (%.2f > %.2f)", b.get("week"), o["total_cost"], b["total_cost"])

--- a/src/methods/booked.py
+++ b/src/methods/booked.py
@@ -1,9 +1,3 @@
-"""Booked-time baseline.
-
-Uses the surgeon's booked duration as the planning input.  This is the
-status-quo benchmark: the planner trusts the booking without correction.
-"""
-
 from __future__ import annotations
 
 import numpy as np
@@ -11,59 +5,29 @@ import pandas as pd
 
 from src.core.config import Config
 from src.core.types import ScheduleResult, WeeklyInstance
-from src.data.eligibility import EligibilityMaps, build_eligibility_maps
 from src.methods.base import Method
 from src.solvers.deterministic import solve_deterministic
 
 
 class BookedTimeMethod(Method):
-    """Schedule using raw booked durations."""
-
     def __init__(self, config: Config) -> None:
         super().__init__(name="Booked", config=config)
-        self._eligibility: EligibilityMaps | None = None
 
     def fit(self, df_train: pd.DataFrame) -> None:
-        self._eligibility = build_eligibility_maps(df_train, self.config)
+        return None
 
     def plan(self, instance: WeeklyInstance) -> ScheduleResult:
         durations = np.array(instance.booked_durations())
-
-        # Build per-case eligible block sets
-        eligible = _build_case_eligibility(
-            instance, self._eligibility, self.config
-        )
-
         return solve_deterministic(
             cases=instance.cases,
             durations=durations,
             calendar=instance.calendar,
             costs=self.config.costs,
             solver_cfg=self.config.solver,
-            model_name="Booked",
-            eligible_blocks=eligible,
-            mean_turnover=self.config.capacity.mean_turnover_minutes,
+            case_eligible_blocks=instance.case_eligible_blocks,
+            surgeon_day_site_cases=instance.surgeon_day_site_cases,
+            eligibility=instance.eligibility,
+            turnover=self.config.capacity.turnover_minutes,
+            surgeon_grouping=self.config.surgeon_grouping,
+            model_name=self.name,
         )
-
-
-def _build_case_eligibility(instance, eligibility, config):
-    """Build the eligible_blocks dict for all cases in an instance."""
-    if eligibility is None:
-        return None
-
-    from src.core.types import BlockId
-
-    eligible = {}
-    for i, case in enumerate(instance.cases):
-        allowed_rooms = eligibility.eligible_rooms_for_case(
-            service=case.service,
-            surgeon_code=case.surgeon_code,
-            operating_room=case.operating_room,
-            config=config,
-        )
-        if allowed_rooms is not None:
-            eligible[i] = [
-                b.id for b in instance.calendar.candidates
-                if b.room in allowed_rooms
-            ]
-    return eligible if eligible else None

--- a/src/methods/oracle.py
+++ b/src/methods/oracle.py
@@ -1,12 +1,3 @@
-"""Oracle (clairvoyant) baseline.
-
-Schedules using realized surgery durations — information that is NOT
-available at planning time.  This produces a lower bound on achievable
-cost: no implementable method can beat the oracle.
-
-Used as the denominator in regret calculations (paper Section 4.4).
-"""
-
 from __future__ import annotations
 
 import numpy as np
@@ -14,36 +5,31 @@ import pandas as pd
 
 from src.core.config import Config
 from src.core.types import ScheduleResult, WeeklyInstance
-from src.data.eligibility import EligibilityMaps, build_eligibility_maps
 from src.methods.base import Method
-from src.methods.booked import _build_case_eligibility
 from src.solvers.deterministic import solve_deterministic
 
 
 class OracleMethod(Method):
-    """Schedule using perfect-information (actual) durations."""
+    """Diagnostic lower bound (not implementable in operations)."""
 
     def __init__(self, config: Config) -> None:
         super().__init__(name="Oracle", config=config)
-        self._eligibility: EligibilityMaps | None = None
 
     def fit(self, df_train: pd.DataFrame) -> None:
-        self._eligibility = build_eligibility_maps(df_train, self.config)
+        return None
 
     def plan(self, instance: WeeklyInstance) -> ScheduleResult:
         durations = np.array(instance.actual_durations())
-
-        eligible = _build_case_eligibility(
-            instance, self._eligibility, self.config
-        )
-
         return solve_deterministic(
             cases=instance.cases,
             durations=durations,
             calendar=instance.calendar,
             costs=self.config.costs,
             solver_cfg=self.config.solver,
-            model_name="Oracle",
-            eligible_blocks=eligible,
-            mean_turnover=self.config.capacity.mean_turnover_minutes,
+            case_eligible_blocks=instance.case_eligible_blocks,
+            surgeon_day_site_cases=instance.surgeon_day_site_cases,
+            eligibility=instance.eligibility,
+            turnover=self.config.capacity.turnover_minutes,
+            surgeon_grouping=self.config.surgeon_grouping,
+            model_name=self.name,
         )

--- a/src/planning/audit.py
+++ b/src/planning/audit.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+from src.core.types import BlockId, WeeklyInstance, ScheduleResult
+
+
+@dataclass
+class SurgeonAuditResult:
+    multi_block_surgeon_day_sites: int
+    total_surgeon_day_sites: int
+    mean_daily_room_load: float
+    mean_daily_surgical_load: float
+    adaptive_k2_count: int
+
+
+def audit_surgeon_feasibility(instance: WeeklyInstance, schedule: ScheduleResult) -> SurgeonAuditResult:
+    case_by_id = {c.case_id: c for c in instance.cases}
+    groups: Dict[Tuple[str, int, str], set[BlockId]] = {}
+    room_load: Dict[Tuple[str, int, str], float] = {}
+    surg_load: Dict[Tuple[str, int, str], float] = {}
+
+    for a in schedule.assignments:
+        if a.is_deferred:
+            continue
+        c = case_by_id.get(a.case_id)
+        if c is None:
+            continue
+        key = (c.surgeon_code, a.day_index or 0, c.site)
+        groups.setdefault(key, set()).add(a.block_id)
+        room_load[key] = room_load.get(key, 0.0) + c.actual_duration_min
+        surg_load[key] = surg_load.get(key, 0.0) + c.surgical_duration_min
+
+    total = len(instance.surgeon_day_site_cases)
+    multi = sum(1 for s in groups.values() if len(s) > 1)
+    mean_room = (sum(room_load.values()) / max(len(room_load), 1)) if room_load else 0.0
+    mean_surg = (sum(surg_load.values()) / max(len(surg_load), 1)) if surg_load else 0.0
+
+    adaptive_k2 = 0
+    for key, idxs in instance.surgeon_day_site_cases.items():
+        pred = sum(instance.cases[i].booked_duration_min for i in idxs)
+        _, day, site = key
+        max_cap = max((b.capacity_minutes for b in instance.calendar.candidates if b.day_index == day and b.site == site), default=0)
+        if pred > max_cap:
+            adaptive_k2 += 1
+
+    return SurgeonAuditResult(
+        multi_block_surgeon_day_sites=multi,
+        total_surgeon_day_sites=total,
+        mean_daily_room_load=mean_room,
+        mean_daily_surgical_load=mean_surg,
+        adaptive_k2_count=adaptive_k2,
+    )

--- a/src/planning/evaluation.py
+++ b/src/planning/evaluation.py
@@ -1,67 +1,18 @@
-"""Schedule evaluation against realized durations.
-
-This is the single authoritative cost evaluator shared by every method.
-It takes a :class:`ScheduleResult`, the :class:`WeeklyInstance` that was
-planned, and the cost configuration, then computes realised operational
-KPIs using actual surgery durations.
-
-Cost structure (paper Section 4.2):
-    activation:  Σ_{ℓ opened} F_ℓ
-    deferral:    C^d × (number of deferred cases)
-    overtime:    C^o × Σ_{ℓ opened} [load_ℓ − C_ℓ]⁺
-    idle:        C^u × Σ_{ℓ opened} [C_ℓ − load_ℓ]⁺
-
-Closed blocks contribute zero cost.  Overtime is NOT capped here —
-this evaluates what actually happened.
-"""
-
 from __future__ import annotations
 
 import logging
 from typing import Dict
 
 from src.core.config import CostConfig
-from src.core.types import (
-    BlockId,
-    CaseRecord,
-    KPIResult,
-    ScheduleResult,
-    WeeklyInstance,
-)
+from src.core.types import BlockId, CaseRecord, KPIResult, ScheduleResult, WeeklyInstance
 
 logger = logging.getLogger(__name__)
 
 
-def evaluate(
-    instance: WeeklyInstance,
-    schedule: ScheduleResult,
-    costs: CostConfig,
-) -> KPIResult:
-    """Evaluate a schedule against realized durations.
-
-    Parameters
-    ----------
-    instance : WeeklyInstance
-        The planning instance (provides cases and block calendar).
-    schedule : ScheduleResult
-        The scheduling decisions to evaluate, including which blocks
-        were opened.
-    costs : CostConfig
-        Cost coefficients.
-
-    Returns
-    -------
-    KPIResult
-    """
-    calendar = instance.calendar
-
-    # Build lookup from case_id → CaseRecord
+def evaluate(instance: WeeklyInstance, schedule: ScheduleResult, costs: CostConfig, turnover: float = 0.0) -> KPIResult:
     case_map: Dict[int, CaseRecord] = {c.case_id: c for c in instance.cases}
-
-    # Accumulate actual load per opened block
-    block_load: Dict[BlockId, float] = {
-        bid: 0.0 for bid in schedule.opened_blocks
-    }
+    block_load: Dict[BlockId, float] = {bid: 0.0 for bid in schedule.opened_blocks}
+    block_case_count: Dict[BlockId, int] = {bid: 0 for bid in schedule.opened_blocks}
 
     scheduled_count = 0
     deferred_count = 0
@@ -70,38 +21,38 @@ def evaluate(
     for assignment in schedule.assignments:
         case = case_map.get(assignment.case_id)
         if case is None:
-            logger.warning("Case %d not found in instance — skipping.",
-                           assignment.case_id)
             continue
-
         if assignment.is_deferred:
             total_deferral_cost += costs.deferral_per_case
             deferred_count += 1
-        else:
-            bid = assignment.block_id
-            if bid not in block_load:
-                # Assigned to a block that wasn't opened — treat as deferred
-                logger.warning(
-                    "Case %d assigned to block %s which is not opened — "
-                    "treating as deferred.",
-                    assignment.case_id, bid,
-                )
-                total_deferral_cost += costs.deferral_per_case
-                deferred_count += 1
-                continue
-            block_load[bid] += case.actual_duration_min
-            scheduled_count += 1
+            continue
+        bid = assignment.block_id
+        if bid not in block_load:
+            total_deferral_cost += costs.deferral_per_case
+            deferred_count += 1
+            continue
+        block_load[bid] += case.actual_duration_min
+        block_case_count[bid] += 1
+        scheduled_count += 1
 
-    # Compute activation cost for opened blocks
-    total_activation_cost = 0.0
-    for bid in schedule.opened_blocks:
-        total_activation_cost += calendar.activation_cost(bid)
+    total_turnover = 0.0
+    for bid in block_load:
+        k = block_case_count[bid]
+        t = turnover * max(k - 1, 0)
+        block_load[bid] += t
+        total_turnover += t
 
-    # Compute overtime and idle per opened block
+    blocks_by_id = {b.id: b for b in instance.calendar.candidates}
+    total_activation_cost = sum(
+        instance.calendar.activation_cost(bid)
+        for bid in schedule.opened_blocks
+        if not blocks_by_id[bid].is_fixed
+    )
+
     total_overtime = 0.0
     total_idle = 0.0
     for bid, load in block_load.items():
-        cap = calendar.capacity(bid)
+        cap = instance.calendar.capacity(bid)
         if load > cap:
             total_overtime += load - cap
         else:
@@ -109,8 +60,7 @@ def evaluate(
 
     overtime_cost = costs.overtime_per_minute * total_overtime
     idle_cost = costs.idle_per_minute * total_idle
-    total_cost = (total_activation_cost + total_deferral_cost
-                  + overtime_cost + idle_cost)
+    total_cost = total_activation_cost + total_deferral_cost + overtime_cost + idle_cost
 
     return KPIResult(
         total_cost=total_cost,
@@ -120,6 +70,7 @@ def evaluate(
         deferral_cost=total_deferral_cost,
         overtime_minutes=total_overtime,
         idle_minutes=total_idle,
+        turnover_minutes=total_turnover,
         scheduled_count=scheduled_count,
         deferred_count=deferred_count,
         blocks_opened=len(schedule.opened_blocks),

--- a/src/planning/instance.py
+++ b/src/planning/instance.py
@@ -1,13 +1,7 @@
-"""Weekly instance construction.
-
-Converts a raw DataFrame slice for one planning horizon into a typed
-:class:`WeeklyInstance` that every method receives identically.
-"""
-
 from __future__ import annotations
 
 import logging
-from typing import Dict, List
+from typing import Dict, List, Set, Tuple
 
 import pandas as pd
 
@@ -16,6 +10,7 @@ from src.core.types import (
     CaseRecord,
     Col,
     Domain,
+    EligibilityMap,
     WeeklyInstance,
 )
 from src.data.capacity import build_block_calendar
@@ -28,70 +23,63 @@ def build_weekly_instance(
     horizon_start: pd.Timestamp,
     week_index: int,
     config: Config,
-    candidate_pools: Dict[int, List[str]],
+    candidate_pools: Dict[int, List[Tuple[str, str]]],
+    eligibility: EligibilityMap,
+    fixed_templates: Set[Tuple[int, str, str]],
 ) -> WeeklyInstance:
-    """Build a :class:`WeeklyInstance` for one horizon window.
-
-    Parameters
-    ----------
-    df_pool : DataFrame
-        The full scheduling pool (test set).
-    horizon_start : Timestamp
-        First day of the horizon (normally a Monday).
-    week_index : int
-        Ordinal index of this horizon in the experiment.
-    config : Config
-        Provides ``data.horizon_days`` and capacity settings.
-    candidate_pools : dict
-        Weekday → room list, pre-computed from training data via
-        :func:`build_candidate_pools`.
-
-    Returns
-    -------
-    WeeklyInstance
-    """
     horizon_days = config.data.horizon_days
     start = horizon_start.normalize()
     end = start + pd.Timedelta(days=horizon_days - 1)
 
-    start_date = start.date()
-    end_date = end.date()
-
-    # Filter to cases in the horizon window
     actual = pd.to_datetime(df_pool[Col.ACTUAL_START])
-    mask = (actual.dt.normalize().dt.date >= start_date) & (
-        actual.dt.normalize().dt.date <= end_date
-    )
-    df_week = df_pool[mask]
+    mask = (actual.dt.normalize() >= start) & (actual.dt.normalize() <= end)
+    df_week = df_pool[mask].copy()
 
-    # Build block calendar from pre-computed candidate pools
-    calendar = build_block_calendar(candidate_pools, start, config)
-
-    # Convert rows to CaseRecord objects
+    calendar = build_block_calendar(candidate_pools, start, config, fixed_templates=fixed_templates)
     cases = _dataframe_to_cases(df_week)
 
+    case_eligible_blocks: Dict[int, List] = {}
+    for i, case in enumerate(cases):
+        allowed = eligibility.get(case.service, set())
+        if case.service not in eligibility:
+            allowed = {(b.site, b.room) for b in calendar.candidates if b.site == case.site}
+        matched = [b.id for b in calendar.candidates if (b.site, b.room) in allowed]
+        case_eligible_blocks[i] = matched
+
+    surgeon_day_site_cases: Dict[Tuple[str, int, str], List[int]] = {}
+    for i, case in enumerate(cases):
+        day_idx = (pd.Timestamp(case.actual_start).normalize() - start).days
+        key = (case.surgeon_code, int(day_idx), case.site)
+        surgeon_day_site_cases.setdefault(key, []).append(i)
+
     logger.info(
-        "Week %d (%s – %s): %d cases, %d candidate blocks",
-        week_index, start_date, end_date,
-        len(cases), calendar.total_candidates,
+        "Week %d (%s-%s): %d cases, %d candidate blocks",
+        week_index,
+        start.date(),
+        end.date(),
+        len(cases),
+        calendar.total_candidates,
     )
+
     return WeeklyInstance(
         week_index=week_index,
-        start_date=start_date,
-        end_date=end_date,
+        start_date=start.date(),
+        end_date=end.date(),
         cases=cases,
         calendar=calendar,
+        eligibility=eligibility,
+        case_eligible_blocks=case_eligible_blocks,
+        surgeon_day_site_cases=surgeon_day_site_cases,
     )
 
 
 def _dataframe_to_cases(df: pd.DataFrame) -> list[CaseRecord]:
-    """Convert DataFrame rows to a list of CaseRecord objects."""
     records: list[CaseRecord] = []
-    for idx, row in df.iterrows():
+    for _, row in df.iterrows():
         ts = pd.to_datetime(row[Col.ACTUAL_START])
         records.append(
             CaseRecord(
-                case_id=int(idx),
+                case_id=int(row[Col.CASE_UID]),
                 procedure_id=str(row.get(Col.PROCEDURE_ID, Domain.UNKNOWN)),
                 surgeon_code=str(row.get(Col.SURGEON_CODE, Domain.UNKNOWN)),
                 service=str(row.get(Col.CASE_SERVICE, Domain.UNKNOWN)),
@@ -103,6 +91,8 @@ def _dataframe_to_cases(df: pd.DataFrame) -> list[CaseRecord]:
                 week_of_year=int(ts.isocalendar().week),
                 month=ts.month,
                 year=ts.year,
+                site=str(row.get(Col.SITE, "")),
+                surgical_duration_min=float(row.get(Col.SURGICAL_DURATION, 0.0)),
             )
         )
     return records

--- a/src/planning/schedule.py
+++ b/src/planning/schedule.py
@@ -1,90 +1,41 @@
-"""Schedule extraction from solved Gurobi models.
-
-Converts Gurobi decision-variable values into typed
-:class:`ScheduleAssignment` objects.
-"""
+"""Schedule extraction from solved Gurobi models."""
 
 from __future__ import annotations
 
-import logging
-import re
 from typing import List, Optional
 
 import gurobipy as gp
-from gurobipy import GRB
 
-from src.core.types import CaseRecord, ScheduleAssignment, ScheduleResult
-
-logger = logging.getLogger(__name__)
+from src.core.types import BlockId, CaseRecord, ScheduleAssignment, ScheduleResult
 
 
-def extract_schedule_from_model(
-    model: Optional[gp.Model],
-    cases: List[CaseRecord],
-) -> ScheduleResult:
-    """Read assignment / rejection variables from a solved Gurobi model.
-
-    Expects variable names of the form ``x[i,d,b]`` for assignments and
-    ``r[i]`` for rejections, where *i* is a 0-based case index matching
-    the order of *cases*.
-
-    Parameters
-    ----------
-    model : gp.Model or None
-        The solved model.  If ``None`` or infeasible, every case is treated
-        as rejected.
-    cases : list[CaseRecord]
-        Cases in the same order they were indexed in the model.
-
-    Returns
-    -------
-    ScheduleResult
-    """
-    n = len(cases)
-
+def extract_schedule_from_model(model: Optional[gp.Model], cases: List[CaseRecord]) -> ScheduleResult:
     if model is None or model.SolCount == 0:
         status = "NoSolution" if model is None else str(model.Status)
-        return ScheduleResult(
-            assignments=[
-                ScheduleAssignment(case_id=c.case_id) for c in cases
-            ],
-            solver_status=status,
-        )
+        return ScheduleResult(assignments=[ScheduleAssignment(case_id=c.case_id) for c in cases], solver_status=status)
 
-    # Parse Gurobi variable names to extract assignments
-    idx_re = re.compile(r"\d+")
-    assigned: dict[int, tuple[int, int]] = {}    # case_idx → (day, block)
-    rejected: set[int] = set()
-
+    assigned: dict[int, BlockId] = {}
     for var in model.getVars():
-        if abs(var.X) < 0.5:
+        if abs(var.X) < 0.5 or not var.VarName.startswith("x["):
             continue
-        nums = [int(s) for s in idx_re.findall(var.VarName)]
-        if not nums:
-            continue
-        if var.VarName.startswith("x") and len(nums) >= 3:
-            case_idx, day, block = nums[:3]
-            assigned[case_idx] = (day, block)
-        elif var.VarName.startswith("r"):
-            rejected.add(nums[0])
+        # supports x[i,day,site,room]
+        inside = var.VarName[var.VarName.find("[") + 1: var.VarName.rfind("]")]
+        parts = [p.strip() for p in inside.split(",")]
+        if len(parts) >= 4:
+            i = int(parts[0])
+            assigned[i] = BlockId(int(parts[1]), parts[2], parts[3])
 
-    assignments: list[ScheduleAssignment] = []
+    out = []
     for i, case in enumerate(cases):
-        if i in assigned:
-            d, b = assigned[i]
-            assignments.append(
-                ScheduleAssignment(case_id=case.case_id,
-                                   day_index=d, block_index=b)
-            )
+        bid = assigned.get(i)
+        if bid is None:
+            out.append(ScheduleAssignment(case_id=case.case_id))
         else:
-            assignments.append(ScheduleAssignment(case_id=case.case_id))
-
-    obj = model.ObjVal if model.SolCount > 0 else None
-    runtime = getattr(model, "Runtime", 0.0)
+            out.append(ScheduleAssignment(case_id=case.case_id, day_index=bid.day_index, site=bid.site, room=bid.room))
 
     return ScheduleResult(
-        assignments=assignments,
+        assignments=out,
         solver_status=str(model.Status),
-        objective_value=obj,
-        solve_time_seconds=runtime,
+        objective_value=model.ObjVal if model.SolCount > 0 else None,
+        solve_time_seconds=getattr(model, "Runtime", 0.0),
     )

--- a/src/solvers/deterministic.py
+++ b/src/solvers/deterministic.py
@@ -1,63 +1,21 @@
-"""Deterministic single-stage OR assignment solver (paper Section 4).
-
-Given a vector of planning durations, solves a mixed-integer program
-that jointly decides which OR blocks to open, assigns each case to an
-opened block or defers it, and minimises total activation + overtime +
-idle + deferral cost.
-
-Key features:
-  - Eligibility constraints (B_ti): each case can only be assigned to
-    blocks whose room is compatible with the case's service/site.
-  - Turnover-aware block load: effective load includes inter-case
-    turnover time, modeled as (n_cases - 1) × mean_turnover per block.
-  - Symmetry breaking (paper Section 11.4.2):
-    (a) Block-load ordering among identical blocks (eq. 53).
-    (b) Deferral ordering within eligibility classes (eq. 54).
-
-Formulation (paper equations (1)–(5))
---------------------------------------
-Sets:
-    i ∈ {0, …, N-1}          cases
-    ℓ ∈ B_ti                  eligible blocks for case i
-
-Variables:
-    x[i, ℓ] ∈ {0, 1}        case i assigned to block ℓ
-    r[i] ∈ {0, 1}            case i deferred
-    v[ℓ] ∈ {0, 1}            block ℓ opened (staffed)
-    ot[ℓ] ≥ 0                overtime on block ℓ
-    idle[ℓ] ≥ 0              idle time on block ℓ
-
-Constraints:
-    Σ_{ℓ ∈ B_ti} x[i,ℓ] + r[i] = 1            ∀ i    (assign or defer)
-    x[i,ℓ] ≤ v[ℓ]                               ∀ i, ℓ ∈ B_ti  (linking)
-    Σ_i dur[i]·x[i,ℓ] + τ·n[ℓ] − C_ℓ·v[ℓ] ≤ ot[ℓ]     ∀ ℓ    (overtime)
-    C_ℓ·v[ℓ] − Σ_i dur[i]·x[i,ℓ] − τ·n[ℓ] ≤ idle[ℓ]   ∀ ℓ    (idle)
-
-    where n[ℓ] = (Σ_i x[i,ℓ] − 1)⁺ is the number of turnovers.
-
-Symmetry breaking (paper Section 11.4.2):
-    Σ_i d_i·x[i,ℓ1] ≥ Σ_i d_i·x[i,ℓ2]  for identical blocks ℓ1 < ℓ2  (eq. 53)
-    r[i1] ≤ r[i2]  for i1 < i2 in the same eligibility class              (eq. 54)
-"""
-
 from __future__ import annotations
 
 import logging
-from collections import defaultdict
-from typing import Dict, FrozenSet, List, Optional, Set, Tuple
+from typing import Dict, List, Set
 
-import numpy as np
 import gurobipy as gp
+import numpy as np
 from gurobipy import GRB, quicksum
 
-from src.core.config import CostConfig, SolverConfig, Config
+from src.core.config import CostConfig, SolverConfig, SurgeonGroupingConfig
 from src.core.types import (
     BlockCalendar,
     BlockId,
-    CandidateBlock,
     CaseRecord,
+    EligibilityMap,
     ScheduleAssignment,
     ScheduleResult,
+    SurgeonDaySiteCases,
 )
 
 logger = logging.getLogger(__name__)
@@ -69,323 +27,149 @@ def solve_deterministic(
     calendar: BlockCalendar,
     costs: CostConfig,
     solver_cfg: SolverConfig,
+    case_eligible_blocks: Dict[int, List[BlockId]],
+    surgeon_day_site_cases: SurgeonDaySiteCases,
+    eligibility: EligibilityMap,
+    turnover: float,
+    surgeon_grouping: SurgeonGroupingConfig,
     model_name: str = "Deterministic",
-    eligible_blocks: Optional[Dict[int, List[BlockId]]] = None,
-    mean_turnover: float = 0.0,
 ) -> ScheduleResult:
-    """Solve the deterministic assignment MIP with endogenous block opening.
-
-    Parameters
-    ----------
-    cases : list[CaseRecord]
-        Candidate cases.  Length must match *durations*.
-    durations : ndarray, shape (N,)
-        Planning durations for block-load calculations.
-    calendar : BlockCalendar
-        Candidate blocks (each may be opened at an activation cost).
-    costs : CostConfig
-        Cost coefficients (activation, deferral, overtime, idle).
-    solver_cfg : SolverConfig
-        Gurobi parameter overrides.
-    model_name : str
-        Label for the Gurobi model.
-    eligible_blocks : dict, optional
-        Maps case index → list of eligible BlockIds.  If None or missing
-        for a case, the case is eligible for all blocks.
-    mean_turnover : float
-        Mean turnover time (minutes) between consecutive cases in the
-        same block.  Added to the block load as (n_cases - 1) × τ.
-
-    Returns
-    -------
-    ScheduleResult
-        Includes ``opened_blocks`` indicating which candidates were staffed.
-    """
     N = len(cases)
-    assert len(durations) == N, "duration vector length must match case count"
-    blocks = calendar.candidates
+    assert len(durations) == N
 
-    if N == 0 or not blocks:
-        return ScheduleResult(
-            assignments=[ScheduleAssignment(case_id=c.case_id) for c in cases],
-            solver_status="Empty",
-        )
+    blocks_by_id = {b.id: b for b in calendar.candidates}
+    all_block_ids = list(blocks_by_id.keys())
+    fixed_bids = {b.id for b in calendar.fixed_blocks}
+    flex_bids = {b.id for b in calendar.flex_blocks}
+    cap = {b.id: b.capacity_minutes for b in calendar.candidates}
+    f_cost = {b.id: b.activation_cost for b in calendar.candidates}
 
-    # Block data indexed by BlockId
-    all_block_ids = [b.id for b in blocks]
-    cap = {b.id: b.capacity_minutes for b in blocks}
-    f_cost = {b.id: b.activation_cost for b in blocks}
+    if N == 0 or not all_block_ids:
+        return ScheduleResult(assignments=[ScheduleAssignment(case_id=c.case_id) for c in cases], solver_status="Empty")
 
-    # Build per-case eligible block sets
-    case_blocks: List[List[BlockId]] = []
-    for i in range(N):
-        if eligible_blocks is not None and i in eligible_blocks:
-            cb = eligible_blocks[i]
-            # Validate: only keep block IDs that actually exist
-            valid = [bid for bid in cb if bid in cap]
-            case_blocks.append(valid if valid else all_block_ids)
-        else:
-            case_blocks.append(all_block_ids)
-
-    # Precompute which cases can go to each block (for load expressions)
-    block_cases: Dict[BlockId, List[int]] = {bid: [] for bid in all_block_ids}
-    for i in range(N):
-        for bid in case_blocks[i]:
-            block_cases[bid].append(i)
-
-    # ── Identify symmetry groups (paper Section 11.4.2) ──────────────────
-    #
-    # Two blocks are "identical" if they have the same capacity and the
-    # same set of eligible cases.  Any permutation among identical blocks
-    # yields the same cost — this is the symmetry we break.
-    #
-    # Signature: (capacity, frozenset of eligible case indices)
-    block_signature: Dict[BlockId, Tuple[float, FrozenSet[int]]] = {}
-    for bid in all_block_ids:
-        sig = (cap[bid], frozenset(block_cases[bid]))
-        block_signature[bid] = sig
-
-    # Group blocks by signature
-    sig_to_blocks: Dict[
-        Tuple[float, FrozenSet[int]], List[BlockId]
-    ] = defaultdict(list)
-    for bid in all_block_ids:
-        sig_to_blocks[block_signature[bid]].append(bid)
-
-    # Only groups with ≥ 2 blocks have symmetry to break
-    sym_groups = [bids for bids in sig_to_blocks.values() if len(bids) >= 2]
-    n_sym_constrs = sum(len(g) - 1 for g in sym_groups)
-
-    # ── Identify deferral equivalence classes (paper eq. 54) ─────────────
-    #
-    # Cases with identical eligibility sets are interchangeable for
-    # deferral: since the deferral penalty C^d is flat (not case-specific),
-    # the solver is indifferent about which case in a class gets deferred.
-    # Ordering by index eliminates this permutation.
-    elig_signature: Dict[int, FrozenSet[BlockId]] = {}
-    for i in range(N):
-        elig_signature[i] = frozenset(case_blocks[i])
-
-    sig_to_cases: Dict[FrozenSet[BlockId], List[int]] = defaultdict(list)
-    for i in range(N):
-        sig_to_cases[elig_signature[i]].append(i)
-
-    defer_groups = [
-        clist for clist in sig_to_cases.values() if len(clist) >= 2
-    ]
-    n_defer_constrs = sum(len(g) - 1 for g in defer_groups)
-
-    # Log eligibility and symmetry stats
-    avg_eligible = np.mean([len(cb) for cb in case_blocks])
-    logger.info(
-        "%s: %d cases, %d blocks, avg %.1f eligible/case, "
-        "turnover=%.1f min, %d block-sym constrs (%d groups), "
-        "%d defer-order constrs (%d classes)",
-        model_name, N, len(blocks), avg_eligible, mean_turnover,
-        n_sym_constrs, len(sym_groups),
-        n_defer_constrs, len(defer_groups),
-    )
-
-    # ── Build model ──────────────────────────────────────────────────────
     model = gp.Model(model_name)
     _apply_solver_params(model, solver_cfg)
 
-    # Assignment variables: x[i, bid] only for eligible (i, bid) pairs
     x = {}
-    for i in range(N):
-        for bid in case_blocks[i]:
-            x[i, bid] = model.addVar(
-                vtype=GRB.BINARY,
-                name=f"x[{i},{bid[0]},{bid[1]}]",
-            )
-
-    # Deferral variables
     r = model.addVars(N, vtype=GRB.BINARY, name="r")
+    v = model.addVars(list(flex_bids), vtype=GRB.BINARY, name="v")
+    ot = model.addVars(all_block_ids, lb=0.0, name="ot")
+    idle = model.addVars(all_block_ids, lb=0.0, name="idle")
 
-    # Block-opening variables
-    v = model.addVars(all_block_ids, vtype=GRB.BINARY, name="v")
+    def v_expr(bid: BlockId):
+        return 1 if bid in fixed_bids else v[bid]
 
-    # Overtime and idle auxiliaries
-    ot = model.addVars(
-        all_block_ids, lb=0.0, ub=costs.max_overtime_minutes, name="ot")
-    idle = model.addVars(
-        all_block_ids, lb=0.0, name="idle")
-
-    # Turnover auxiliaries (only needed if turnover > 0)
-    if mean_turnover > 0:
-        n_assigned = {}
-        for bid in all_block_ids:
-            n_assigned[bid] = model.addVar(
-                lb=0.0, name=f"nc[{bid[0]},{bid[1]}]")
-        tv_load = {}
-        for bid in all_block_ids:
-            tv_load[bid] = model.addVar(
-                lb=0.0, name=f"tv[{bid[0]},{bid[1]}]")
-
-    # ── Core constraints ─────────────────────────────────────────────────
-
-    # (1) Assign to an eligible block or defer
+    forced_defer = 0
     for i in range(N):
-        model.addConstr(
-            quicksum(x[i, bid] for bid in case_blocks[i]) + r[i] == 1,
-            name=f"assign_{i}",
-        )
+        elig = [bid for bid in case_eligible_blocks.get(i, []) if bid in blocks_by_id]
+        if not elig:
+            model.addConstr(r[i] == 1, name=f"force_defer_{i}")
+            forced_defer += 1
+            continue
+        for bid in elig:
+            x[i, bid] = model.addVar(vtype=GRB.BINARY, name=f"x[{i},{bid.day_index},{bid.site},{bid.room}]")
+        model.addConstr(quicksum(x[i, bid] for bid in elig) + r[i] == 1, name=f"assign_{i}")
+        for bid in elig:
+            model.addConstr(x[i, bid] <= v_expr(bid), name=f"link_{i}_{bid.day_index}_{bid.site}_{bid.room}")
 
-    # (2) Linking: no case assigned to a closed block
-    for i in range(N):
-        for bid in case_blocks[i]:
-            model.addConstr(
-                x[i, bid] <= v[bid],
-                name=f"link_{i}_{bid[0]}_{bid[1]}",
-            )
+    block_cases: Dict[BlockId, List[int]] = {bid: [] for bid in all_block_ids}
+    for (i, bid) in x:
+        block_cases[bid].append(i)
 
-    # Block load and overtime/idle accounting
+    y_used = {}
+    for bid in all_block_ids:
+        eligible_i = block_cases[bid]
+        M_bid = len(eligible_i)
+        if M_bid == 0:
+            if bid in flex_bids:
+                model.addConstr(v[bid] == 0)
+            continue
+        y_used[bid] = model.addVar(vtype=GRB.BINARY, name=f"y[{bid.day_index},{bid.site},{bid.room}]")
+        n_bid = quicksum(x[i, bid] for i in eligible_i)
+        model.addConstr(n_bid <= M_bid * y_used[bid])
+        model.addConstr(n_bid >= y_used[bid])
+        model.addConstr(y_used[bid] <= v_expr(bid))
+
     for bid in all_block_ids:
         eligible_i = block_cases[bid]
         if not eligible_i:
-            # No case can reach this block — force it closed
-            model.addConstr(v[bid] == 0, name=f"empty_{bid[0]}_{bid[1]}")
             continue
+        case_load = quicksum(durations[i] * x[i, bid] for i in eligible_i)
+        n_bid = quicksum(x[i, bid] for i in eligible_i)
+        turnover_load = turnover * (n_bid - y_used[bid])
+        load = case_load + turnover_load
+        cap_val = cap[bid] * v_expr(bid)
+        model.addConstr(load - cap_val <= ot[bid])
+        model.addConstr(cap_val - load <= idle[bid])
 
-        surgical_load = quicksum(
-            durations[i] * x[i, bid] for i in eligible_i
-        )
+    u = {}
+    adaptive_k2 = 0
+    for (surg, day, site_key), case_idxs in surgeon_day_site_cases.items():
+        services_today = {cases[i].service for i in case_idxs}
+        eligible_site_rooms = set()
+        for svc in services_today:
+            eligible_site_rooms |= eligibility.get(svc, set())
+        for bid in all_block_ids:
+            block = blocks_by_id[bid]
+            if bid.day_index == day and block.site == site_key and (block.site, block.room) in eligible_site_rooms:
+                u[surg, day, site_key, bid] = model.addVar(vtype=GRB.BINARY, name=f"u[{surg},{day},{site_key},{bid.room}]")
 
-        if mean_turnover > 0:
-            # n_assigned[bid] = Σ_i x[i, bid]
-            model.addConstr(
-                n_assigned[bid] == quicksum(
-                    x[i, bid] for i in eligible_i
-                ),
-                name=f"nc_def_{bid[0]}_{bid[1]}",
-            )
-            # tv_load[bid] ≥ (n_assigned - 1) × τ
-            model.addConstr(
-                tv_load[bid] >= (n_assigned[bid] - 1) * mean_turnover,
-                name=f"tv_lb_{bid[0]}_{bid[1]}",
-            )
-            total_load = surgical_load + tv_load[bid]
+    for i, case in enumerate(cases):
+        for bid in case_eligible_blocks.get(i, []):
+            key = (case.surgeon_code, bid.day_index, case.site, bid)
+            if (i, bid) in x and key in u:
+                model.addConstr(x[i, bid] <= u[key])
+
+    for (surg, day, site_key), case_idxs in surgeon_day_site_cases.items():
+        predicted_load = sum(durations[i] for i in case_idxs) + turnover * max(len(case_idxs) - 1, 0)
+        max_cap = max((cap[bid] for bid in all_block_ids if (surg, day, site_key, bid) in u), default=0)
+        K_sd = 1 if predicted_load <= max_cap else 2
+        if K_sd == 2:
+            adaptive_k2 += 1
+        if not surgeon_grouping.adaptive_relaxation:
+            K_sd = surgeon_grouping.default_max_blocks_per_day
+        day_u = [u[surg, day, site_key, bid] for bid in all_block_ids if (surg, day, site_key, bid) in u]
+        if day_u:
+            model.addConstr(quicksum(day_u) <= K_sd)
+
+    for (surg, day, site_key, bid), uvar in u.items():
+        relevant = [i for i in surgeon_day_site_cases.get((surg, day, site_key), []) if (i, bid) in x]
+        if relevant:
+            model.addConstr(uvar <= quicksum(x[i, bid] for i in relevant))
         else:
-            total_load = surgical_load
+            uvar.ub = 0
 
-        # ot[ℓ] ≥ total_load − C_ℓ · v[ℓ]
-        model.addConstr(
-            total_load - cap[bid] * v[bid] <= ot[bid],
-            name=f"ot_{bid[0]}_{bid[1]}",
-        )
-        # idle[ℓ] ≥ C_ℓ · v[ℓ] − total_load
-        model.addConstr(
-            cap[bid] * v[bid] - total_load <= idle[bid],
-            name=f"idle_{bid[0]}_{bid[1]}",
-        )
-
-    # ── Symmetry breaking: block-load ordering (paper eq. 53) ────────────
-    #
-    # For each group of identical blocks (same capacity, same eligible
-    # case set), impose decreasing block load by index.  If blocks ℓ1 and
-    # ℓ2 are interchangeable and ℓ1 < ℓ2, then:
-    #
-    #     Σ_i d_i · x[i, ℓ1] ≥ Σ_i d_i · x[i, ℓ2]
-    #
-    # This eliminates all permutations of the same assignment across
-    # identical blocks.  E.g., if 5 ORTH-eligible rooms exist on Tuesday,
-    # this cuts out 5! − 1 = 119 equivalent solutions.
-    # for group in sym_groups:
-    #     for j in range(len(group) - 1):
-    #         bid1 = group[j]
-    #         bid2 = group[j + 1]
-    #         eligible_i = block_cases[bid1]  # same for bid2 by construction
-    #         if not eligible_i:
-    #             continue
-    #         load1 = quicksum(
-    #             durations[i] * x[i, bid1] for i in eligible_i
-    #         )
-    #         load2 = quicksum(
-    #             durations[i] * x[i, bid2] for i in eligible_i
-    #         )
-    #         model.addConstr(
-    #             load1 >= load2,
-    #             name=f"sym_load_{bid1[0]}_{bid1[1]}_{bid2[1]}",
-    #         )
-
-    # ── Symmetry breaking: deferral ordering (paper eq. 54) ──────────────
-    #
-    # Within each eligibility class (cases with identical B_ti), the flat
-    # deferral penalty makes the solver indifferent about which case to
-    # defer.  Force deferrals onto higher-indexed cases:
-    #
-    #     r[i1] ≤ r[i2]    for i1 < i2 in the same class
-    #
-    # This is valid because C^d is case-independent: deferring case i1
-    # vs i2 has the same cost, so we can impose an order without loss.
-    for group in defer_groups:
-        for j in range(len(group) - 1):
-            i1 = group[j]
-            i2 = group[j + 1]
-            model.addConstr(
-                r[i1] <= r[i2],
-                name=f"sym_def_{i1}_{i2}",
-            )
-
-    # ── Objective ────────────────────────────────────────────────────────
-    activation = quicksum(f_cost[bid] * v[bid] for bid in all_block_ids)
+    activation = quicksum(f_cost[bid] * v[bid] for bid in flex_bids)
     deferral = costs.deferral_per_case * quicksum(r[i] for i in range(N))
-    overtime = costs.overtime_per_minute * quicksum(
-        ot[bid] for bid in all_block_ids
-    )
-    idletime = costs.idle_per_minute * quicksum(
-        idle[bid] for bid in all_block_ids
-    )
+    overtime = costs.overtime_per_minute * quicksum(ot[bid] for bid in all_block_ids)
+    idletime = costs.idle_per_minute * quicksum(idle[bid] for bid in all_block_ids)
+    model.setObjective(activation + deferral + overtime + idletime, GRB.MINIMIZE)
 
-    model.setObjective(
-        activation + deferral + overtime + idletime, GRB.MINIMIZE
-    )
-
-    # ── Solve ────────────────────────────────────────────────────────────
     model.optimize()
 
     if model.SolCount == 0:
-        logger.warning(
-            "%s: no feasible solution found (status %d).",
-            model_name, model.Status,
-        )
-        return ScheduleResult(
-            assignments=[
-                ScheduleAssignment(case_id=c.case_id) for c in cases
-            ],
-            solver_status=str(model.Status),
-            solve_time_seconds=getattr(model, "Runtime", 0.0),
-        )
+        return ScheduleResult(assignments=[ScheduleAssignment(case_id=c.case_id) for c in cases], solver_status=str(model.Status), solve_time_seconds=getattr(model, "Runtime", 0.0))
 
-    # ── Extract solution ─────────────────────────────────────────────────
-    opened: Set[BlockId] = set()
-    for bid in all_block_ids:
+    opened: Set[BlockId] = set(fixed_bids)
+    for bid in flex_bids:
         if v[bid].X > 0.5:
             opened.add(bid)
 
     assignments: list[ScheduleAssignment] = []
     for i, case in enumerate(cases):
-        assigned = False
-        for bid in case_blocks[i]:
-            if x[i, bid].X > 0.5:
-                assignments.append(
-                    ScheduleAssignment(
-                        case_id=case.case_id,
-                        day_index=bid[0],
-                        block_index=bid[1],
-                    )
-                )
-                assigned = True
+        assigned_bid = None
+        for bid in case_eligible_blocks.get(i, []):
+            if (i, bid) in x and x[i, bid].X > 0.5:
+                assigned_bid = bid
                 break
-        if not assigned:
+        if assigned_bid is None:
             assignments.append(ScheduleAssignment(case_id=case.case_id))
+        else:
+            assignments.append(ScheduleAssignment(case_id=case.case_id, day_index=assigned_bid.day_index, site=assigned_bid.site, room=assigned_bid.room))
 
-    n_deferred = sum(1 for a in assignments if a.is_deferred)
     logger.info(
-        "%s solved: obj=%.1f  status=%d  time=%.1fs  "
-        "blocks_opened=%d/%d  deferred=%d/%d",
-        model_name, model.ObjVal, model.Status, model.Runtime,
-        len(opened), len(blocks), n_deferred, N,
+        "%s model size: x=%d u=%d v_flex=%d y=%d forced_defer=%d k2=%d",
+        model_name, len(x), len(u), len(flex_bids), len(y_used), forced_defer, adaptive_k2,
     )
 
     return ScheduleResult(
@@ -398,9 +182,8 @@ def solve_deterministic(
 
 
 def _apply_solver_params(model: gp.Model, cfg: SolverConfig) -> None:
-    """Set Gurobi parameters from the solver config."""
     model.Params.TimeLimit = cfg.time_limit_seconds
     model.Params.MIPGap = cfg.mip_gap
     model.Params.Threads = cfg.threads
     model.Params.OutputFlag = 1 if cfg.verbose else 0
-    model.Params.MIPFocus = 1       # bias toward feasibility
+    model.Params.MIPFocus = 1

--- a/src/validation.py
+++ b/src/validation.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import logging
+
+from src.core.config import Config
+from src.core.types import WeeklyInstance, ScheduleResult
+
+logger = logging.getLogger(__name__)
+
+
+def validate_week(instance: WeeklyInstance, schedule: ScheduleResult, config: Config, method_name: str) -> None:
+    if any(c.actual_duration_min <= 0 for c in instance.cases):
+        logger.warning("%s week %d: non-positive actual duration found", method_name, instance.week_index)
+
+    if len(set(instance.calendar.block_ids)) != len(instance.calendar.block_ids):
+        logger.warning("%s week %d: duplicate block IDs", method_name, instance.week_index)
+
+    eligible_map = {i: set(bids) for i, bids in instance.case_eligible_blocks.items()}
+    case_index = {c.case_id: i for i, c in enumerate(instance.cases)}
+    for a in schedule.assignments:
+        if a.is_deferred:
+            continue
+        i = case_index.get(a.case_id)
+        if i is None:
+            continue
+        if a.block_id not in eligible_map.get(i, set()):
+            logger.warning("%s week %d: ineligible assignment case_id=%s bid=%s", method_name, instance.week_index, a.case_id, a.block_id)
+
+    fixed_ids = {b.id for b in instance.calendar.fixed_blocks}
+    missing_fixed = fixed_ids - set(schedule.opened_blocks)
+    if missing_fixed:
+        logger.warning("%s week %d: missing fixed opened blocks count=%d", method_name, instance.week_index, len(missing_fixed))
+
+    if config.capacity.turnover_minutes < 0:
+        logger.warning("Negative turnover parameter configured")


### PR DESCRIPTION
### Motivation
- Align the data pipeline and deterministic solver with the paper (Sections 3–4) so the planner can act as the CCG follower core and produce auditable Booked/Oracle baselines.  
- Use room-time as the realized duration with provenance flags and strict timestamp handling to ensure correct load accounting.  
- Enforce experiment scope (TGH + TWH, weekdays) and make BlockId semantic (day, site, room) so site-aware eligibility, capacity templates, and surgeon-day-site grouping are correct and auditable.

### Description
- Config and types: renamed `mean_turnover_minutes` → `turnover_minutes` (default `32.0`), added `eligibility_min_weeks` and `fixed_block_threshold`, introduced `SurgeonGroupingConfig` and `ExperimentScopeConfig`, and migrated `BlockId` to a `NamedTuple(day_index, site, room)` while updating `CandidateBlock`, `ScheduleAssignment`, `WeeklyInstance`, KPI and calendar helpers.  
- Loader and provenance: computed `surgical_duration_min` and `room_duration_min`, enforced timestamp ordering (drop severe, mark mild), applied overhead cap fallback, set `procedure_duration_min` to room-time with surgical fallback, normalized/imputed `site`, and wrote stable `case_uid`.  
- Scope, eligibility, capacity: added `src/data/scope.py` for weekday/site filtering; refactored eligibility to map services → set of `(site, room)` using `(iso_year, iso_week)` counts and strict fallback rules; candidate pools now return weekday → `[(site, room)]` and `classify_fixed_flex` identifies fixed templates; `build_block_calendar` emits site-aware `CandidateBlock` with `is_fixed`.  
- Instance & solver: `build_weekly_instance` precomputes `case_eligible_blocks` and `surgeon_day_site_cases` (keyed by surgeon, day, site); `solve_deterministic` signature now accepts those precomputed structures and `eligibility`, implements fixed-vs-flex handling (fixed blocks open by construction), exact turnover with `y_used` binaries, surgeon-day-site `u` variables with adaptive K logic, forced-defer for zero-eligibility cases, and site-aware solution extraction.  
- Evaluation, methods, runner, audit, validation: evaluation charges realized turnover and counts flex-only activation costs; Booked/Oracle methods become thin wrappers consuming instance structure; runner computes eligibility from full warm-up, scopes warm-up/pool for templates and planning, persists preprocessing artifacts and per-week diagnostics, and now steps by `config.scope.stride_days`; added `src/planning/audit.py` and `src/validation.py` for post-run checks.

### Testing
- Code compiled successfully with `python -m compileall -q src run_experiment.py`, indicating no syntax/import errors.  
- Attempted data sanity check with `from src.data.loader import load_data` and a `--quick` experiment run, but both failed at runtime because the Excel dataset `data/UHNOperating_RoomScheduling2011-2013.xlsx` is not present in the execution environment.  
- Performed static inspections (searches and cross-file updates) and exercised `run_experiment.py` invocation to validate wiring; the end-to-end numeric validation and horizon experiments require the dataset and therefore were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c30a32a76c832bade6c781af35aa3c)