### PR TITLE
Add phase-1 estimation scaffolding, config, and persistence utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "scikit-learn>=1.2",
     "gurobipy>=10.0",
     "openpyxl>=3.1",
+    "joblib>=1.3",
 ]
 
 [project.optional-dependencies]

--- a/scripts/run_estimation.py
+++ b/scripts/run_estimation.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Command-line entry point for the estimation pipeline."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.estimation.serialization import DEFAULT_PATH
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the surgery duration estimation pipeline."
+    )
+    parser.add_argument(
+        "--data",
+        type=Path,
+        default=None,
+        help="Optional override path to the warm-up training dataset.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_PATH,
+        help=f"Path to write estimation artifacts (default: {DEFAULT_PATH}).",
+    )
+    parser.add_argument(
+        "--skip-profiles",
+        action="store_true",
+        help="Skip response profile generation.",
+    )
+    parser.add_argument(
+        "--skip-bootstrap",
+        action="store_true",
+        help="Skip bootstrap confidence interval estimation.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Reduce logging output.",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    parser.parse_args()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -58,6 +58,57 @@ class ExperimentScopeConfig:
 
 
 @dataclass
+class QuantileModelConfig:
+    q_grid_size: int = 99
+    alpha: float = 0.01
+    solver: str = "highs"
+    max_iter: int = 10000
+
+
+@dataclass
+class InverseConfig:
+    n_min: int = 50
+    q_grid_size: int = 99
+    pooling_lambda: float = 50.0
+
+
+@dataclass
+class ResponseConfig:
+    delta_max_days: int = 60
+    n_folds: int = 5
+    min_pairs: int = 30
+    h_grid_max: float = 60.0
+    h_grid_step: float = 2.0
+    a_min: float = 0.01
+    a_max: float = 1.0
+
+
+@dataclass
+class ProfileConfig:
+    n_profiles_per_service: int = 3
+    min_profiles_total: int = 5
+    max_profiles_total: int = 20
+
+
+@dataclass
+class BootstrapConfig:
+    n_bootstrap: int = 200
+    random_seed: int = 42
+    n_jobs: int = 1
+    q_grid_size_bootstrap: int = 25
+    n_folds_bootstrap: int = 3
+
+
+@dataclass
+class EstimationConfig:
+    quantile_model: QuantileModelConfig = field(default_factory=QuantileModelConfig)
+    inverse: InverseConfig = field(default_factory=InverseConfig)
+    response: ResponseConfig = field(default_factory=ResponseConfig)
+    profile: ProfileConfig = field(default_factory=ProfileConfig)
+    bootstrap: BootstrapConfig = field(default_factory=BootstrapConfig)
+
+
+@dataclass
 class Config:
     data: DataConfig = field(default_factory=DataConfig)
     capacity: CapacityConfig = field(default_factory=CapacityConfig)
@@ -65,6 +116,7 @@ class Config:
     costs: CostConfig = field(default_factory=CostConfig)
     solver: SolverConfig = field(default_factory=SolverConfig)
     scope: ExperimentScopeConfig = field(default_factory=ExperimentScopeConfig)
+    estimation: EstimationConfig = field(default_factory=EstimationConfig)
 
 
 CONFIG = Config()

--- a/src/diagnostics/__init__.py
+++ b/src/diagnostics/__init__.py
@@ -1,0 +1,1 @@
+"""Diagnostics package for estimation and optimization outputs."""

--- a/src/estimation/__init__.py
+++ b/src/estimation/__init__.py
@@ -1,0 +1,21 @@
+"""Shared estimation package types."""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .bootstrap import BootstrapEstimator
+    from .inverse import CriticalRatioEstimator
+    from .quantile import QuantileModel
+    from .response import ResponseEstimator, ResponseProfiler
+
+
+@dataclass
+class EstimationResult:
+    """Container for estimation artifacts shared across phases."""
+
+    quantile_model: "QuantileModel | Any"
+    critical_ratios: "CriticalRatioEstimator | Any"
+    response_estimator: "ResponseEstimator | Any"
+    response_profiler: "ResponseProfiler | Any"
+    bootstrap: "BootstrapEstimator | Any | None" = None

--- a/src/estimation/serialization.py
+++ b/src/estimation/serialization.py
@@ -1,0 +1,20 @@
+"""Persistence helpers for estimation artifacts."""
+
+from pathlib import Path
+
+import joblib
+
+DEFAULT_PATH = Path("outputs/estimation_artifacts.joblib")
+
+
+def save_estimation(result, path: Path = DEFAULT_PATH) -> Path:
+    """Persist estimation artifacts to disk using joblib."""
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    joblib.dump(result, output_path)
+    return output_path
+
+
+def load_estimation(path: Path = DEFAULT_PATH):
+    """Load persisted estimation artifacts from disk."""
+    return joblib.load(Path(path))


### PR DESCRIPTION
### Motivation
- Provide Phase-1 scaffolding for the surgery-duration estimation pipeline including shared config, types, and persistence without adding any modeling logic yet.
- Make estimation artifacts importable, serializable, and accessible from a simple CLI so later chunks can implement algorithms against stable interfaces.

### Description
- Add estimation-related dataclasses to `src/core/config.py` (`QuantileModelConfig`, `InverseConfig`, `ResponseConfig`, `ProfileConfig`, `BootstrapConfig`, `EstimationConfig`) and wire `estimation: EstimationConfig` into the top-level `Config` with the requested defaults.
- Add a shared `EstimationResult` dataclass in `src/estimation/__init__.py` using `TYPE_CHECKING` and forward-referenced types to avoid circular imports and to act as a container for artifacts (quantile model, critical ratios, response estimator/profiler, optional bootstrap).
- Implement persistence helpers in `src/estimation/serialization.py` with `DEFAULT_PATH` and `save_estimation` / `load_estimation` backed by `joblib` and ensuring output directories are created.
- Add a lightweight CLI skeleton `scripts/run_estimation.py` that is import-safe and exposes flags `--data`, `--output`, `--skip-profiles`, `--skip-bootstrap`, and `--quiet` with a `main()` stub.
- Add package dependency `joblib` to `pyproject.toml` and create `src/diagnostics` package scaffold.

### Testing
- Verified `Config().estimation.quantile_model.q_grid_size == 99` succeeded.
- Verified a dummy `EstimationResult` can be persisted and loaded back using `save_estimation` and `load_estimation` (roundtrip succeeded).
- Verified CLI help displays via `python scripts/run_estimation.py --help` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c432c2ae5c832b8e534ac64ec055ad)