### PR TITLE
Add conditional quantile estimation, serialization, configs, CLI stub, and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "scikit-learn>=1.2",
     "gurobipy>=10.0",
     "openpyxl>=3.1",
+    "joblib>=1.3",
 ]
 
 [project.optional-dependencies]

--- a/scripts/run_estimation.py
+++ b/scripts/run_estimation.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Command-line entry point for the estimation pipeline."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.estimation.serialization import DEFAULT_PATH
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the surgery duration estimation pipeline."
+    )
+    parser.add_argument(
+        "--data",
+        type=Path,
+        default=None,
+        help="Optional override path to the warm-up training dataset.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_PATH,
+        help=f"Path to write estimation artifacts (default: {DEFAULT_PATH}).",
+    )
+    parser.add_argument(
+        "--skip-profiles",
+        action="store_true",
+        help="Skip response profile generation.",
+    )
+    parser.add_argument(
+        "--skip-bootstrap",
+        action="store_true",
+        help="Skip bootstrap confidence interval estimation.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Reduce logging output.",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    parser.parse_args()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -58,6 +58,57 @@ class ExperimentScopeConfig:
 
 
 @dataclass
+class QuantileModelConfig:
+    q_grid_size: int = 99
+    alpha: float = 0.01
+    solver: str = "highs"
+    max_iter: int = 10000
+
+
+@dataclass
+class InverseConfig:
+    n_min: int = 50
+    q_grid_size: int = 99
+    pooling_lambda: float = 50.0
+
+
+@dataclass
+class ResponseConfig:
+    delta_max_days: int = 60
+    n_folds: int = 5
+    min_pairs: int = 30
+    h_grid_max: float = 60.0
+    h_grid_step: float = 2.0
+    a_min: float = 0.01
+    a_max: float = 1.0
+
+
+@dataclass
+class ProfileConfig:
+    n_profiles_per_service: int = 3
+    min_profiles_total: int = 5
+    max_profiles_total: int = 20
+
+
+@dataclass
+class BootstrapConfig:
+    n_bootstrap: int = 200
+    random_seed: int = 42
+    n_jobs: int = 1
+    q_grid_size_bootstrap: int = 25
+    n_folds_bootstrap: int = 3
+
+
+@dataclass
+class EstimationConfig:
+    quantile_model: QuantileModelConfig = field(default_factory=QuantileModelConfig)
+    inverse: InverseConfig = field(default_factory=InverseConfig)
+    response: ResponseConfig = field(default_factory=ResponseConfig)
+    profile: ProfileConfig = field(default_factory=ProfileConfig)
+    bootstrap: BootstrapConfig = field(default_factory=BootstrapConfig)
+
+
+@dataclass
 class Config:
     data: DataConfig = field(default_factory=DataConfig)
     capacity: CapacityConfig = field(default_factory=CapacityConfig)
@@ -65,6 +116,7 @@ class Config:
     costs: CostConfig = field(default_factory=CostConfig)
     solver: SolverConfig = field(default_factory=SolverConfig)
     scope: ExperimentScopeConfig = field(default_factory=ExperimentScopeConfig)
+    estimation: EstimationConfig = field(default_factory=EstimationConfig)
 
 
 CONFIG = Config()

--- a/src/diagnostics/__init__.py
+++ b/src/diagnostics/__init__.py
@@ -1,0 +1,1 @@
+"""Diagnostics package for estimation and optimization outputs."""

--- a/src/estimation/__init__.py
+++ b/src/estimation/__init__.py
@@ -1,0 +1,21 @@
+"""Shared estimation package types."""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .bootstrap import BootstrapEstimator
+    from .inverse import CriticalRatioEstimator
+    from .quantile import QuantileModel
+    from .response import ResponseEstimator, ResponseProfiler
+
+
+@dataclass
+class EstimationResult:
+    """Container for estimation artifacts shared across phases."""
+
+    quantile_model: "QuantileModel | Any"
+    critical_ratios: "CriticalRatioEstimator | Any"
+    response_estimator: "ResponseEstimator | Any"
+    response_profiler: "ResponseProfiler | Any"
+    bootstrap: "BootstrapEstimator | Any | None" = None

--- a/src/estimation/quantile_model.py
+++ b/src/estimation/quantile_model.py
@@ -1,0 +1,145 @@
+"""Conditional quantile model for surgery duration estimation."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+from sklearn.compose import ColumnTransformer
+from sklearn.linear_model import QuantileRegressor
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+
+from src.core.config import QuantileModelConfig
+from src.core.types import Col
+
+
+class ConditionalQuantileModel:
+    """Fits conditional quantile surfaces Q(x, s; q) over a fixed quantile grid."""
+
+    def __init__(self, config: QuantileModelConfig | None = None) -> None:
+        self.config = config or QuantileModelConfig()
+        self.numeric_features = ["_proc_median_duration", "_proc_log_volume"]
+        self.categorical_features = [
+            Col.SURGEON_CODE,
+            Col.CASE_SERVICE,
+            Col.PROCEDURE_ID,
+            "_month_str",
+        ]
+        self.feature_columns = self.numeric_features + self.categorical_features
+
+        self._proc_median: dict[str, float] = {}
+        self._proc_count: dict[str, float] = {}
+        self._global_median: float = 0.0
+        self._quantile_grid = np.linspace(0.01, 0.99, self.config.q_grid_size)
+        self._preprocessor: ColumnTransformer | None = None
+        self._models: Dict[float, QuantileRegressor] = {}
+
+    @property
+    def is_fitted(self) -> bool:
+        return self._preprocessor is not None and len(self._models) > 0
+
+    def fit(self, df: pd.DataFrame) -> "ConditionalQuantileModel":
+        self._validate_columns(df)
+
+        proc_stats = df.groupby(Col.PROCEDURE_ID)[Col.PROCEDURE_DURATION].agg(["median", "count"])
+        self._proc_median = proc_stats["median"].to_dict()
+        self._proc_count = proc_stats["count"].astype(float).to_dict()
+        self._global_median = float(df[Col.PROCEDURE_DURATION].median())
+
+        X_df = self._build_features(df)
+        y = df[Col.PROCEDURE_DURATION].to_numpy(dtype=float)
+
+        self._preprocessor = ColumnTransformer(
+            transformers=[
+                ("num", StandardScaler(), self.numeric_features),
+                (
+                    "cat",
+                    OneHotEncoder(handle_unknown="ignore", sparse_output=False),
+                    self.categorical_features,
+                ),
+            ]
+        )
+        X = self._preprocessor.fit_transform(X_df)
+
+        self._models = {}
+        for q in self._quantile_grid:
+            model = QuantileRegressor(
+                quantile=float(q),
+                alpha=self.config.alpha,
+                solver=self.config.solver,
+                solver_options={"maxiter": self.config.max_iter},
+            )
+            model.fit(X, y)
+            self._models[float(q)] = model
+
+        return self
+
+    def predict(self, df: pd.DataFrame, q: float) -> np.ndarray:
+        self._require_fitted()
+        q_snap = self._snap_quantile(float(q))
+        X = self._transform_features(df)
+        preds = self._models[q_snap].predict(X)
+        return np.clip(preds, 30.0, 1440.0)
+
+    def predict_grid(
+        self, df: pd.DataFrame, q_grid: np.ndarray | None = None
+    ) -> Dict[float, np.ndarray]:
+        self._require_fitted()
+        grid = self._quantile_grid if q_grid is None else np.asarray(q_grid, dtype=float)
+        X = self._transform_features(df)
+
+        out: Dict[float, np.ndarray] = {}
+        for q in grid:
+            q_snap = self._snap_quantile(float(q))
+            out[q_snap] = np.clip(self._models[q_snap].predict(X), 30.0, 1440.0)
+        return out
+
+    def fit_excluding(self, df: pd.DataFrame, exclude_mask: np.ndarray) -> "ConditionalQuantileModel":
+        mask = np.asarray(exclude_mask, dtype=bool)
+        if len(mask) != len(df):
+            raise ValueError("exclude_mask length must match dataframe length")
+        new_model = ConditionalQuantileModel(config=replace(self.config))
+        return new_model.fit(df.loc[~mask].copy())
+
+    def _build_features(self, df: pd.DataFrame) -> pd.DataFrame:
+        out = pd.DataFrame(index=df.index)
+        procedure_series = df[Col.PROCEDURE_ID]
+        out["_proc_median_duration"] = (
+            procedure_series.map(self._proc_median).fillna(self._global_median).astype(float)
+        )
+        out["_proc_log_volume"] = np.log1p(procedure_series.map(self._proc_count).fillna(0.0)).astype(
+            float
+        )
+        out[Col.SURGEON_CODE] = df[Col.SURGEON_CODE].astype(str)
+        out[Col.CASE_SERVICE] = df[Col.CASE_SERVICE].astype(str)
+        out[Col.PROCEDURE_ID] = procedure_series.astype(str)
+        out["_month_str"] = df[Col.MONTH].astype(str)
+        return out
+
+    def _transform_features(self, df: pd.DataFrame) -> np.ndarray:
+        self._require_fitted()
+        self._validate_columns(df)
+        X_df = self._build_features(df)
+        return self._preprocessor.transform(X_df)  # type: ignore[union-attr]
+
+    def _snap_quantile(self, q: float) -> float:
+        idx = int(np.argmin(np.abs(self._quantile_grid - q)))
+        return float(self._quantile_grid[idx])
+
+    def _require_fitted(self) -> None:
+        if not self.is_fitted:
+            raise RuntimeError("ConditionalQuantileModel must be fitted before prediction")
+
+    def _validate_columns(self, df: pd.DataFrame) -> None:
+        required = [
+            Col.PROCEDURE_ID,
+            Col.PROCEDURE_DURATION,
+            Col.SURGEON_CODE,
+            Col.CASE_SERVICE,
+            Col.MONTH,
+        ]
+        missing = [c for c in required if c not in df.columns]
+        if missing:
+            raise ValueError(f"Missing required columns: {missing}")

--- a/src/estimation/serialization.py
+++ b/src/estimation/serialization.py
@@ -1,0 +1,20 @@
+"""Persistence helpers for estimation artifacts."""
+
+from pathlib import Path
+
+import joblib
+
+DEFAULT_PATH = Path("outputs/estimation_artifacts.joblib")
+
+
+def save_estimation(result, path: Path = DEFAULT_PATH) -> Path:
+    """Persist estimation artifacts to disk using joblib."""
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    joblib.dump(result, output_path)
+    return output_path
+
+
+def load_estimation(path: Path = DEFAULT_PATH):
+    """Load persisted estimation artifacts from disk."""
+    return joblib.load(Path(path))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_estimation/test_quantile_model.py
+++ b/tests/test_estimation/test_quantile_model.py
@@ -1,0 +1,108 @@
+import numpy as np
+import pandas as pd
+
+from src.core.config import QuantileModelConfig
+from src.core.types import Col
+from src.estimation.quantile_model import ConditionalQuantileModel
+
+
+def _synthetic_df(n: int = 220, seed: int = 7) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    procedures = np.array(["P1", "P2", "P3", "P4"])
+    surgeons = np.array(["S1", "S2", "S3"])
+    services = np.array(["SvcA", "SvcB"])
+
+    proc = rng.choice(procedures, size=n, p=[0.4, 0.3, 0.2, 0.1])
+    surg = rng.choice(surgeons, size=n)
+    svc = rng.choice(services, size=n)
+    month = rng.integers(1, 13, size=n)
+
+    proc_effect = {"P1": 70, "P2": 110, "P3": 150, "P4": 220}
+    surg_effect = {"S1": -8, "S2": 0, "S3": 12}
+    svc_effect = {"SvcA": 0, "SvcB": 10}
+
+    duration = np.array([
+        proc_effect[p] + surg_effect[s] + svc_effect[v] + rng.normal(0, 18)
+        for p, s, v in zip(proc, surg, svc)
+    ])
+    duration = np.clip(duration, 30, 500)
+
+    return pd.DataFrame(
+        {
+            Col.PROCEDURE_ID: proc,
+            Col.SURGEON_CODE: surg,
+            Col.CASE_SERVICE: svc,
+            Col.MONTH: month,
+            Col.PROCEDURE_DURATION: duration,
+            Col.BOOKED_MINUTES: duration + rng.normal(0, 15, size=n),
+        }
+    )
+
+
+def test_fit_and_predict_shapes():
+    df = _synthetic_df()
+    model = ConditionalQuantileModel(QuantileModelConfig(q_grid_size=15)).fit(df)
+    preds = model.predict(df.head(25), q=0.5)
+
+    assert model.is_fitted
+    assert preds.shape == (25,)
+    assert np.isfinite(preds).all()
+
+
+def test_predict_grid_keys():
+    df = _synthetic_df()
+    model = ConditionalQuantileModel(QuantileModelConfig(q_grid_size=9)).fit(df)
+    grid = np.array([0.1, 0.5, 0.9])
+    pred_map = model.predict_grid(df.head(10), q_grid=grid)
+
+    expected_keys = {model._snap_quantile(q) for q in grid}
+    assert set(pred_map.keys()) == expected_keys
+    for arr in pred_map.values():
+        assert arr.shape == (10,)
+
+
+def test_fit_excluding_returns_new_model():
+    df = _synthetic_df()
+    model = ConditionalQuantileModel(QuantileModelConfig(q_grid_size=7)).fit(df)
+    original_models_id = id(model._models)
+
+    exclude_mask = np.zeros(len(df), dtype=bool)
+    exclude_mask[:20] = True
+    new_model = model.fit_excluding(df, exclude_mask)
+
+    assert new_model is not model
+    assert new_model.is_fitted
+    assert model.is_fitted
+    assert id(model._models) == original_models_id
+
+
+def test_no_booked_time_in_features():
+    df = _synthetic_df()
+    model = ConditionalQuantileModel(QuantileModelConfig(q_grid_size=5)).fit(df)
+
+    names = model._preprocessor.get_feature_names_out().tolist()
+    assert all("booked" not in name.lower() for name in names)
+    assert Col.BOOKED_MINUTES not in model.feature_columns
+
+
+def test_predictions_are_clipped():
+    df = _synthetic_df()
+    df.loc[:15, Col.PROCEDURE_DURATION] = 5000.0
+    model = ConditionalQuantileModel(QuantileModelConfig(q_grid_size=11)).fit(df)
+
+    preds = model.predict(df, q=0.99)
+    assert (preds >= 30.0).all()
+    assert (preds <= 1440.0).all()
+
+
+def test_quantile_monotonicity_on_sample():
+    df = _synthetic_df(n=260)
+    model = ConditionalQuantileModel(QuantileModelConfig(q_grid_size=21)).fit(df)
+
+    sample = df.sample(40, random_state=2)
+    p10 = model.predict(sample, q=0.10)
+    p50 = model.predict(sample, q=0.50)
+    p90 = model.predict(sample, q=0.90)
+
+    gross_violations = np.mean((p50 < p10 - 5.0) | (p90 < p50 - 5.0))
+    assert gross_violations < 0.2


### PR DESCRIPTION
### Motivation

- Introduce the core estimation pieces required to fit conditional quantile surfaces for surgery duration estimation and to persist/load artifacts for downstream pipelines.
- Provide configuration knobs for estimation phases (quantile model, inverse, response profiling, bootstrap) so experiments can be tuned centrally.
- Add a minimal CLI entrypoint to run the estimation pipeline and a diagnostics package placeholder to organize outputs.

### Description

- Implement `ConditionalQuantileModel` in `src/estimation/quantile_model.py` to fit per-quantile `QuantileRegressor` models over a configurable quantile grid and expose `predict`, `predict_grid`, and `fit_excluding` methods. 
- Add configuration dataclasses (`QuantileModelConfig`, `InverseConfig`, `ResponseConfig`, `ProfileConfig`, `BootstrapConfig`, `EstimationConfig`) and attach an `estimation` field to the global `Config` in `src/core/config.py`.
- Add persistence helpers using `joblib` in `src/estimation/serialization.py` and expose a small CLI stub `scripts/run_estimation.py` that wires project import paths and argument parsing for future pipeline invocation.
- Add lightweight package scaffolding: `src/estimation/__init__.py` (shared `EstimationResult` type) and `src/diagnostics/__init__.py`, and declare `joblib>=1.3` as a dependency in `pyproject.toml`.
- Add unit tests exercising the quantile model (`tests/test_estimation/test_quantile_model.py`) and a `tests/conftest.py` entry to ensure the repository root is on `sys.path` for tests.

### Testing

- Ran the new quantile-model unit tests with `pytest tests/test_estimation -q` and all tests in that module passed. 
- No other automated test suites were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c432c2ae5c832b8e534ac64ec055ad)