### PR TITLE
Add estimation package (quantile model, inverse/response estimators, profiling), CLI, and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "scikit-learn>=1.2",
     "gurobipy>=10.0",
     "openpyxl>=3.1",
+    "joblib>=1.3",
 ]
 
 [project.optional-dependencies]

--- a/scripts/run_estimation.py
+++ b/scripts/run_estimation.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Command-line entry point for the estimation pipeline."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.estimation.serialization import DEFAULT_PATH
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the surgery duration estimation pipeline."
+    )
+    parser.add_argument(
+        "--data",
+        type=Path,
+        default=None,
+        help="Optional override path to the warm-up training dataset.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_PATH,
+        help=f"Path to write estimation artifacts (default: {DEFAULT_PATH}).",
+    )
+    parser.add_argument(
+        "--skip-profiles",
+        action="store_true",
+        help="Skip response profile generation.",
+    )
+    parser.add_argument(
+        "--skip-bootstrap",
+        action="store_true",
+        help="Skip bootstrap confidence interval estimation.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Reduce logging output.",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    parser.parse_args()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -58,6 +58,57 @@ class ExperimentScopeConfig:
 
 
 @dataclass
+class QuantileModelConfig:
+    q_grid_size: int = 99
+    alpha: float = 0.01
+    solver: str = "highs"
+    max_iter: int = 10000
+
+
+@dataclass
+class InverseConfig:
+    n_min: int = 50
+    q_grid_size: int = 99
+    pooling_lambda: float = 50.0
+
+
+@dataclass
+class ResponseConfig:
+    delta_max_days: int = 60
+    n_folds: int = 5
+    min_pairs: int = 30
+    h_grid_max: float = 60.0
+    h_grid_step: float = 2.0
+    a_min: float = 0.01
+    a_max: float = 1.0
+
+
+@dataclass
+class ProfileConfig:
+    n_profiles_per_service: int = 3
+    min_profiles_total: int = 5
+    max_profiles_total: int = 20
+
+
+@dataclass
+class BootstrapConfig:
+    n_bootstrap: int = 200
+    random_seed: int = 42
+    n_jobs: int = 1
+    q_grid_size_bootstrap: int = 25
+    n_folds_bootstrap: int = 3
+
+
+@dataclass
+class EstimationConfig:
+    quantile_model: QuantileModelConfig = field(default_factory=QuantileModelConfig)
+    inverse: InverseConfig = field(default_factory=InverseConfig)
+    response: ResponseConfig = field(default_factory=ResponseConfig)
+    profile: ProfileConfig = field(default_factory=ProfileConfig)
+    bootstrap: BootstrapConfig = field(default_factory=BootstrapConfig)
+
+
+@dataclass
 class Config:
     data: DataConfig = field(default_factory=DataConfig)
     capacity: CapacityConfig = field(default_factory=CapacityConfig)
@@ -65,6 +116,7 @@ class Config:
     costs: CostConfig = field(default_factory=CostConfig)
     solver: SolverConfig = field(default_factory=SolverConfig)
     scope: ExperimentScopeConfig = field(default_factory=ExperimentScopeConfig)
+    estimation: EstimationConfig = field(default_factory=EstimationConfig)
 
 
 CONFIG = Config()

--- a/src/diagnostics/__init__.py
+++ b/src/diagnostics/__init__.py
@@ -1,0 +1,1 @@
+"""Diagnostics package for estimation and optimization outputs."""

--- a/src/estimation/__init__.py
+++ b/src/estimation/__init__.py
@@ -1,0 +1,21 @@
+"""Shared estimation package types."""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .bootstrap import BootstrapEstimator
+    from .inverse import CriticalRatioEstimator
+    from .quantile import QuantileModel
+    from .response import ResponseEstimator, ResponseProfiler
+
+
+@dataclass
+class EstimationResult:
+    """Container for estimation artifacts shared across phases."""
+
+    quantile_model: "QuantileModel | Any"
+    critical_ratios: "CriticalRatioEstimator | Any"
+    response_estimator: "ResponseEstimator | Any"
+    response_profiler: "ResponseProfiler | Any"
+    bootstrap: "BootstrapEstimator | Any | None" = None

--- a/src/estimation/inverse.py
+++ b/src/estimation/inverse.py
@@ -1,0 +1,130 @@
+"""Inverse critical-ratio estimation by quantile matching."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+
+from src.core.config import InverseConfig
+from src.core.types import Col, Domain
+
+
+class CriticalRatioEstimator:
+    """Estimate surgeon-specific critical ratios by inverse quantile matching."""
+
+    def __init__(self, quantile_model, config: InverseConfig | None = None) -> None:
+        self.quantile_model = quantile_model
+        self.config = config or InverseConfig()
+        self._ratios: Dict[str, float] = {}
+
+    @property
+    def is_fitted(self) -> bool:
+        return len(self._ratios) > 0
+
+    def fit(self, df_train: pd.DataFrame) -> "CriticalRatioEstimator":
+        required = [Col.SURGEON_CODE, Col.CASE_SERVICE, Col.BOOKED_MINUTES]
+        missing = [c for c in required if c not in df_train.columns]
+        if missing:
+            raise ValueError(f"Missing required columns: {missing}")
+
+        df = df_train.copy()
+        grouped = df.groupby(Col.SURGEON_CODE)
+        surgeon_counts = grouped.size().to_dict()
+        surgeon_service = grouped[Col.CASE_SERVICE].agg(lambda x: x.mode().iat[0]).to_dict()
+
+        individual_q: Dict[str, float] = {}
+        for surgeon, g in grouped:
+            if surgeon == Domain.OTHER:
+                continue
+            individual_q[surgeon] = self._estimate_individual_ratio(g)
+
+        rich_surgeons = [
+            s
+            for s in individual_q
+            if surgeon_counts.get(s, 0) >= self.config.n_min and s != Domain.OTHER
+        ]
+
+        service_logits: Dict[str, float] = {}
+        for service, values in self._group_by_service(rich_surgeons, individual_q, surgeon_service).items():
+            service_logits[service] = float(np.mean([self._logit(v) for v in values]))
+
+        if rich_surgeons:
+            grand_logit = float(np.mean([self._logit(individual_q[s]) for s in rich_surgeons]))
+        else:
+            grand_logit = self._logit(0.5)
+
+        ratios: Dict[str, float] = {}
+        for surgeon, n_cases in surgeon_counts.items():
+            if surgeon == Domain.OTHER:
+                continue
+
+            if surgeon in rich_surgeons:
+                q_hat = individual_q[surgeon]
+            else:
+                theta_target = service_logits.get(surgeon_service[surgeon], grand_logit)
+                if n_cases < 10:
+                    q_hat = self._sigmoid(theta_target)
+                else:
+                    theta_ind = self._logit(individual_q[surgeon])
+                    w = n_cases / (n_cases + self.config.pooling_lambda)
+                    q_hat = self._sigmoid(w * theta_ind + (1.0 - w) * theta_target)
+            ratios[surgeon] = self._clip_ratio(q_hat)
+
+        non_other = [q for s, q in ratios.items() if s != Domain.OTHER]
+        if non_other:
+            ratios[Domain.OTHER] = self._clip_ratio(float(np.median(non_other)))
+        else:
+            ratios[Domain.OTHER] = 0.5
+
+        self._ratios = ratios
+        return self
+
+    def get_ratio(self, surgeon_code: str) -> float:
+        self._require_fitted()
+        return self._ratios.get(surgeon_code, self._ratios[Domain.OTHER])
+
+    def get_all_ratios(self) -> Dict[str, float]:
+        self._require_fitted()
+        return dict(self._ratios)
+
+    def get_misalignment(self, surgeon_code: str, co: float, cu: float) -> float:
+        target = co / (co + cu)
+        return self.get_ratio(surgeon_code) - target
+
+    def _estimate_individual_ratio(self, surgeon_df: pd.DataFrame) -> float:
+        pred_grid = self.quantile_model.predict_grid(surgeon_df)
+        q_vals = np.array(sorted(pred_grid.keys()), dtype=float)
+        booked = surgeon_df[Col.BOOKED_MINUTES].to_numpy(dtype=float)
+        sse = np.array([
+            np.square(booked - pred_grid[q]).sum() for q in q_vals
+        ])
+        best_idx = int(np.argmin(sse))
+        return self._clip_ratio(float(q_vals[best_idx]))
+
+    def _group_by_service(
+        self,
+        surgeons: list[str],
+        individual_q: Dict[str, float],
+        surgeon_service: Dict[str, str],
+    ) -> Dict[str, list[float]]:
+        grouped: Dict[str, list[float]] = {}
+        for s in surgeons:
+            svc = surgeon_service[s]
+            grouped.setdefault(svc, []).append(individual_q[s])
+        return grouped
+
+    def _clip_ratio(self, q: float) -> float:
+        return float(np.clip(q, 0.01, 0.99))
+
+    def _logit(self, q: float) -> float:
+        q_clip = self._clip_ratio(q)
+        return float(np.log(q_clip / (1.0 - q_clip)))
+
+    def _sigmoid(self, x: float) -> float:
+        return float(1.0 / (1.0 + np.exp(-x)))
+
+    def _require_fitted(self) -> None:
+        if not self.is_fitted:
+            raise RuntimeError("CriticalRatioEstimator must be fitted before access")

--- a/src/estimation/profiles.py
+++ b/src/estimation/profiles.py
@@ -1,0 +1,172 @@
+"""Response profile clustering and SOS2 knot generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.cluster import KMeans
+
+from src.core.config import ProfileConfig
+from src.core.types import Domain
+
+
+@dataclass
+class ResponseProfile:
+    profile_id: int
+    a: float
+    h_plus: float
+    h_minus: float
+    n_surgeons: int
+    service: str
+
+
+class ResponseProfiler:
+    def __init__(self, config: ProfileConfig | None = None) -> None:
+        self.config = config or ProfileConfig()
+        self._profiles: dict[int, ResponseProfile] = {}
+        self._surgeon_to_profile: dict[str, int] = {}
+        self._other_profile_id: int | None = None
+
+    @property
+    def n_profiles(self) -> int:
+        return len(self._profiles)
+
+    def fit(self, params_df: pd.DataFrame, surgeon_services: Dict[str, str]) -> "ResponseProfiler":
+        required = {"surgeon_code", "a", "h_plus", "h_minus", "is_individual"}
+        missing = required - set(params_df.columns)
+        if missing:
+            raise ValueError(f"Missing required columns: {sorted(missing)}")
+
+        df = params_df.copy()
+        df["service"] = df["surgeon_code"].map(surgeon_services).fillna(Domain.OTHER)
+
+        individual = df[df["is_individual"].astype(bool)].copy()
+        pooled = df[~df["is_individual"].astype(bool)].copy()
+
+        self._profiles = {}
+        self._surgeon_to_profile = {}
+        next_pid = 0
+
+        for service in sorted(df["service"].unique().tolist()):
+            svc_all = df[df["service"] == service]
+            svc_ind = individual[individual["service"] == service]
+
+            if len(svc_ind) == 0:
+                center = svc_all[["a", "h_plus", "h_minus"]].mean().to_numpy(dtype=float)
+                pid = next_pid
+                next_pid += 1
+                self._profiles[pid] = ResponseProfile(pid, float(center[0]), float(center[1]), float(center[2]), 0, service)
+                service_profile_ids = [pid]
+            elif len(svc_ind) < self.config.n_profiles_per_service:
+                center = svc_ind[["a", "h_plus", "h_minus"]].mean().to_numpy(dtype=float)
+                pid = next_pid
+                next_pid += 1
+                self._profiles[pid] = ResponseProfile(pid, float(center[0]), float(center[1]), float(center[2]), 0, service)
+                service_profile_ids = [pid]
+            else:
+                k = min(self.config.n_profiles_per_service, len(svc_ind))
+                X = svc_ind[["a", "h_plus", "h_minus"]].to_numpy(dtype=float)
+                km = KMeans(n_clusters=k, random_state=42, n_init=10)
+                labels = km.fit_predict(X)
+                centers = km.cluster_centers_
+                order = np.lexsort((centers[:, 2], centers[:, 1], centers[:, 0]))
+                remap = {old: new for new, old in enumerate(order)}
+                labels = np.array([remap[l] for l in labels], dtype=int)
+                centers = centers[order]
+
+                service_profile_ids = []
+                for c in range(k):
+                    pid = next_pid
+                    next_pid += 1
+                    center = centers[c]
+                    self._profiles[pid] = ResponseProfile(
+                        profile_id=pid,
+                        a=float(center[0]),
+                        h_plus=float(center[1]),
+                        h_minus=float(center[2]),
+                        n_surgeons=0,
+                        service=service,
+                    )
+                    service_profile_ids.append(pid)
+
+                for surgeon, label in zip(svc_ind["surgeon_code"].tolist(), labels):
+                    pid = service_profile_ids[int(label)]
+                    self._surgeon_to_profile[surgeon] = pid
+
+            svc_profiles = [self._profiles[pid] for pid in service_profile_ids]
+
+            for surgeon in svc_ind[~svc_ind["surgeon_code"].isin(self._surgeon_to_profile)]["surgeon_code"]:
+                self._surgeon_to_profile[str(surgeon)] = service_profile_ids[0]
+
+            svc_pooled = pooled[pooled["service"] == service]
+            for _, row in svc_pooled.iterrows():
+                vec = np.array([row["a"], row["h_plus"], row["h_minus"]], dtype=float)
+                distances = [np.linalg.norm(vec - np.array([p.a, p.h_plus, p.h_minus])) for p in svc_profiles]
+                best_local = int(np.argmin(distances))
+                self._surgeon_to_profile[str(row["surgeon_code"])] = service_profile_ids[best_local]
+
+        for surgeon, pid in self._surgeon_to_profile.items():
+            p = self._profiles[pid]
+            self._profiles[pid] = ResponseProfile(p.profile_id, p.a, p.h_plus, p.h_minus, p.n_surgeons + 1, p.service)
+
+        if len(individual) > 0:
+            other_center = individual[["a", "h_plus", "h_minus"]].mean().to_numpy(dtype=float)
+        else:
+            other_center = np.array([0.3, 15.0, 15.0], dtype=float)
+
+        other_pid = next_pid
+        self._other_profile_id = other_pid
+        self._profiles[other_pid] = ResponseProfile(
+            profile_id=other_pid,
+            a=float(other_center[0]),
+            h_plus=float(other_center[1]),
+            h_minus=float(other_center[2]),
+            n_surgeons=0,
+            service=Domain.OTHER,
+        )
+        self._surgeon_to_profile[Domain.OTHER] = other_pid
+
+        for s in params_df["surgeon_code"].astype(str).tolist():
+            self._surgeon_to_profile.setdefault(s, other_pid)
+
+        return self
+
+    def get_profile(self, surgeon_code: str) -> ResponseProfile:
+        pid = self.get_profile_id(surgeon_code)
+        return self._profiles[pid]
+
+    def get_profile_id(self, surgeon_code: str) -> int:
+        if self._other_profile_id is None:
+            raise RuntimeError("ResponseProfiler must be fitted before access")
+        return self._surgeon_to_profile.get(surgeon_code, self._other_profile_id)
+
+    def get_all_profiles(self) -> List[ResponseProfile]:
+        return [self._profiles[k] for k in sorted(self._profiles)]
+
+    def get_sos2_knots(
+        self, profile_id: int, L_ti: float, U_ti: float, b_ti: float
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        if profile_id not in self._profiles:
+            raise KeyError(f"Unknown profile_id={profile_id}")
+        p = self._profiles[profile_id]
+
+        left_range = max(0.0, b_ti - L_ti)
+        right_range = max(0.0, U_ti - b_ti)
+        h_minus = min(max(0.0, p.h_minus), left_range)
+        h_plus = min(max(0.0, p.h_plus), right_range)
+
+        x = np.array([L_ti - b_ti, -h_minus, 0.0, h_plus, U_ti - b_ti], dtype=float)
+        y = np.array(
+            [
+                p.a * ((L_ti - b_ti) + h_minus),
+                0.0,
+                0.0,
+                0.0,
+                p.a * ((U_ti - b_ti) - h_plus),
+            ],
+            dtype=float,
+        )
+        return x, y

--- a/src/estimation/quantile_model.py
+++ b/src/estimation/quantile_model.py
@@ -1,0 +1,145 @@
+"""Conditional quantile model for surgery duration estimation."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+from sklearn.compose import ColumnTransformer
+from sklearn.linear_model import QuantileRegressor
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+
+from src.core.config import QuantileModelConfig
+from src.core.types import Col
+
+
+class ConditionalQuantileModel:
+    """Fits conditional quantile surfaces Q(x, s; q) over a fixed quantile grid."""
+
+    def __init__(self, config: QuantileModelConfig | None = None) -> None:
+        self.config = config or QuantileModelConfig()
+        self.numeric_features = ["_proc_median_duration", "_proc_log_volume"]
+        self.categorical_features = [
+            Col.SURGEON_CODE,
+            Col.CASE_SERVICE,
+            Col.PROCEDURE_ID,
+            "_month_str",
+        ]
+        self.feature_columns = self.numeric_features + self.categorical_features
+
+        self._proc_median: dict[str, float] = {}
+        self._proc_count: dict[str, float] = {}
+        self._global_median: float = 0.0
+        self._quantile_grid = np.linspace(0.01, 0.99, self.config.q_grid_size)
+        self._preprocessor: ColumnTransformer | None = None
+        self._models: Dict[float, QuantileRegressor] = {}
+
+    @property
+    def is_fitted(self) -> bool:
+        return self._preprocessor is not None and len(self._models) > 0
+
+    def fit(self, df: pd.DataFrame) -> "ConditionalQuantileModel":
+        self._validate_columns(df)
+
+        proc_stats = df.groupby(Col.PROCEDURE_ID)[Col.PROCEDURE_DURATION].agg(["median", "count"])
+        self._proc_median = proc_stats["median"].to_dict()
+        self._proc_count = proc_stats["count"].astype(float).to_dict()
+        self._global_median = float(df[Col.PROCEDURE_DURATION].median())
+
+        X_df = self._build_features(df)
+        y = df[Col.PROCEDURE_DURATION].to_numpy(dtype=float)
+
+        self._preprocessor = ColumnTransformer(
+            transformers=[
+                ("num", StandardScaler(), self.numeric_features),
+                (
+                    "cat",
+                    OneHotEncoder(handle_unknown="ignore", sparse_output=False),
+                    self.categorical_features,
+                ),
+            ]
+        )
+        X = self._preprocessor.fit_transform(X_df)
+
+        self._models = {}
+        for q in self._quantile_grid:
+            model = QuantileRegressor(
+                quantile=float(q),
+                alpha=self.config.alpha,
+                solver=self.config.solver,
+                solver_options={"maxiter": self.config.max_iter},
+            )
+            model.fit(X, y)
+            self._models[float(q)] = model
+
+        return self
+
+    def predict(self, df: pd.DataFrame, q: float) -> np.ndarray:
+        self._require_fitted()
+        q_snap = self._snap_quantile(float(q))
+        X = self._transform_features(df)
+        preds = self._models[q_snap].predict(X)
+        return np.clip(preds, 30.0, 1440.0)
+
+    def predict_grid(
+        self, df: pd.DataFrame, q_grid: np.ndarray | None = None
+    ) -> Dict[float, np.ndarray]:
+        self._require_fitted()
+        grid = self._quantile_grid if q_grid is None else np.asarray(q_grid, dtype=float)
+        X = self._transform_features(df)
+
+        out: Dict[float, np.ndarray] = {}
+        for q in grid:
+            q_snap = self._snap_quantile(float(q))
+            out[q_snap] = np.clip(self._models[q_snap].predict(X), 30.0, 1440.0)
+        return out
+
+    def fit_excluding(self, df: pd.DataFrame, exclude_mask: np.ndarray) -> "ConditionalQuantileModel":
+        mask = np.asarray(exclude_mask, dtype=bool)
+        if len(mask) != len(df):
+            raise ValueError("exclude_mask length must match dataframe length")
+        new_model = ConditionalQuantileModel(config=replace(self.config))
+        return new_model.fit(df.loc[~mask].copy())
+
+    def _build_features(self, df: pd.DataFrame) -> pd.DataFrame:
+        out = pd.DataFrame(index=df.index)
+        procedure_series = df[Col.PROCEDURE_ID]
+        out["_proc_median_duration"] = (
+            procedure_series.map(self._proc_median).fillna(self._global_median).astype(float)
+        )
+        out["_proc_log_volume"] = np.log1p(procedure_series.map(self._proc_count).fillna(0.0)).astype(
+            float
+        )
+        out[Col.SURGEON_CODE] = df[Col.SURGEON_CODE].astype(str)
+        out[Col.CASE_SERVICE] = df[Col.CASE_SERVICE].astype(str)
+        out[Col.PROCEDURE_ID] = procedure_series.astype(str)
+        out["_month_str"] = df[Col.MONTH].astype(str)
+        return out
+
+    def _transform_features(self, df: pd.DataFrame) -> np.ndarray:
+        self._require_fitted()
+        self._validate_columns(df)
+        X_df = self._build_features(df)
+        return self._preprocessor.transform(X_df)  # type: ignore[union-attr]
+
+    def _snap_quantile(self, q: float) -> float:
+        idx = int(np.argmin(np.abs(self._quantile_grid - q)))
+        return float(self._quantile_grid[idx])
+
+    def _require_fitted(self) -> None:
+        if not self.is_fitted:
+            raise RuntimeError("ConditionalQuantileModel must be fitted before prediction")
+
+    def _validate_columns(self, df: pd.DataFrame) -> None:
+        required = [
+            Col.PROCEDURE_ID,
+            Col.PROCEDURE_DURATION,
+            Col.SURGEON_CODE,
+            Col.CASE_SERVICE,
+            Col.MONTH,
+        ]
+        missing = [c for c in required if c not in df.columns]
+        if missing:
+            raise ValueError(f"Missing required columns: {missing}")

--- a/src/estimation/response.py
+++ b/src/estimation/response.py
@@ -1,0 +1,298 @@
+"""Response-model data preparation utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from src.core.config import ResponseConfig
+from src.core.types import Col, Domain
+
+
+@dataclass
+class SurgeonResponseParams:
+    surgeon_code: str
+    a: float
+    h_plus: float
+    h_minus: float
+    n_pairs: int
+    is_individual: bool
+
+
+class ResponseEstimator:
+    """Prepare residualized pair data for surgeon response estimation."""
+
+    def __init__(self, quantile_model, critical_ratios, config: ResponseConfig | None = None) -> None:
+        self._qmodel = quantile_model
+        self._critical = critical_ratios
+        self.config = config or ResponseConfig()
+        self._params: dict[str, SurgeonResponseParams] = {}
+        self._residualized_pairs: pd.DataFrame | None = None
+        self._r_hat: np.ndarray | None = None
+        self._u_hat: np.ndarray | None = None
+
+    @property
+    def is_fitted(self) -> bool:
+        return len(self._params) > 0
+
+    def fit(self, df_train: pd.DataFrame) -> "ResponseEstimator":
+        self._validate_columns(df_train)
+        pairs = self._build_consecutive_pairs(df_train)
+        r_hat, u_hat = self._cross_fitted_residuals(df_train)
+        residualized_pairs = self._build_residualized_pairs(pairs, r_hat, u_hat)
+
+        self._r_hat = r_hat
+        self._u_hat = u_hat
+        self._residualized_pairs = residualized_pairs
+
+        surgeon_service = (
+            df_train.groupby(Col.SURGEON_CODE)[Col.CASE_SERVICE]
+            .agg(lambda x: x.mode().iat[0])
+            .to_dict()
+        )
+
+        individual_params: dict[str, SurgeonResponseParams] = {}
+        for surgeon, g in residualized_pairs.groupby("surgeon_code", sort=False):
+            if surgeon == Domain.OTHER or len(g) < self.config.min_pairs:
+                continue
+            a, hp, hm, _ = self._profile_least_squares(
+                g["X"].to_numpy(dtype=float),
+                g["Y"].to_numpy(dtype=float),
+            )
+            individual_params[surgeon] = SurgeonResponseParams(
+                surgeon_code=surgeon,
+                a=a,
+                h_plus=hp,
+                h_minus=hm,
+                n_pairs=int(len(g)),
+                is_individual=True,
+            )
+
+        service_params: dict[str, tuple[float, float, float]] = {}
+        for service, g in residualized_pairs.groupby("service", sort=False):
+            if len(g) < self.config.min_pairs:
+                continue
+            a, hp, hm, _ = self._profile_least_squares(
+                g["X"].to_numpy(dtype=float),
+                g["Y"].to_numpy(dtype=float),
+            )
+            service_params[service] = (a, hp, hm)
+
+        if len(residualized_pairs) > 0:
+            g_all = residualized_pairs
+            a_g, hp_g, hm_g, _ = self._profile_least_squares(
+                g_all["X"].to_numpy(dtype=float),
+                g_all["Y"].to_numpy(dtype=float),
+            )
+        else:
+            a_g, hp_g, hm_g = self.config.a_min, 0.0, 0.0
+
+        global_default = SurgeonResponseParams(
+            surgeon_code=Domain.OTHER,
+            a=float(a_g),
+            h_plus=float(hp_g),
+            h_minus=float(hm_g),
+            n_pairs=int(len(residualized_pairs)),
+            is_individual=False,
+        )
+
+        params: dict[str, SurgeonResponseParams] = {}
+        for surgeon in df_train[Col.SURGEON_CODE].astype(str).unique():
+            if surgeon in individual_params:
+                params[surgeon] = individual_params[surgeon]
+                continue
+
+            service = surgeon_service.get(surgeon, "")
+            pooled = service_params.get(service, (global_default.a, global_default.h_plus, global_default.h_minus))
+            n_pairs = int((residualized_pairs["surgeon_code"] == surgeon).sum()) if len(residualized_pairs) else 0
+            params[surgeon] = SurgeonResponseParams(
+                surgeon_code=surgeon,
+                a=float(pooled[0]),
+                h_plus=float(pooled[1]),
+                h_minus=float(pooled[2]),
+                n_pairs=n_pairs,
+                is_individual=False,
+            )
+
+        params[Domain.OTHER] = global_default
+        self._params = params
+        return self
+
+    def get_params(self, surgeon_code: str) -> SurgeonResponseParams:
+        self._require_fitted()
+        return self._params.get(surgeon_code, self._params[Domain.OTHER])
+
+    def get_all_params(self) -> pd.DataFrame:
+        self._require_fitted()
+        rows = [
+            {
+                "surgeon_code": p.surgeon_code,
+                "a": p.a,
+                "h_plus": p.h_plus,
+                "h_minus": p.h_minus,
+                "n_pairs": p.n_pairs,
+                "is_individual": p.is_individual,
+            }
+            for p in self._params.values()
+        ]
+        return pd.DataFrame(rows).sort_values("surgeon_code").reset_index(drop=True)
+
+    def _build_consecutive_pairs(self, df_train: pd.DataFrame) -> pd.DataFrame:
+        self._validate_columns(df_train)
+        df = df_train.copy()
+        df["_row_pos"] = np.arange(len(df), dtype=int)
+        df["_completion_time"] = self._completion_time(df)
+
+        sort_cols = [Col.SURGEON_CODE, Col.PROCEDURE_ID, "_completion_time"]
+        df_sorted = df.sort_values(sort_cols)
+
+        rows = []
+        for (_, _), g in df_sorted.groupby([Col.SURGEON_CODE, Col.PROCEDURE_ID], sort=False):
+            g = g.reset_index(drop=True)
+            for i in range(1, len(g)):
+                prev = g.iloc[i - 1]
+                curr = g.iloc[i]
+                if prev[Col.SURGEON_CODE] == Domain.OTHER or prev[Col.PROCEDURE_ID] == Domain.OTHER:
+                    continue
+                gap_days = (curr["_completion_time"] - prev["_completion_time"]).total_seconds() / 86400.0
+                if gap_days < 0 or gap_days > self.config.delta_max_days:
+                    continue
+                rows.append(
+                    {
+                        "surgeon_code": curr[Col.SURGEON_CODE],
+                        "service": curr[Col.CASE_SERVICE],
+                        "curr_idx": int(curr["_row_pos"]),
+                        "prev_idx": int(prev["_row_pos"]),
+                        "gap_days": float(gap_days),
+                    }
+                )
+
+        return pd.DataFrame(rows, columns=["surgeon_code", "service", "curr_idx", "prev_idx", "gap_days"])
+
+    def _assign_case_folds(self, df_train: pd.DataFrame) -> np.ndarray:
+        self._validate_columns(df_train)
+        k = self.config.n_folds
+        if k <= 0:
+            raise ValueError("n_folds must be positive")
+
+        df = df_train.copy()
+        df["_row_pos"] = np.arange(len(df), dtype=int)
+        df["_completion_time"] = self._completion_time(df)
+        folds = np.full(len(df), -1, dtype=int)
+
+        for _, g in df.sort_values([Col.SURGEON_CODE, "_completion_time"]).groupby(Col.SURGEON_CODE, sort=False):
+            row_pos = g["_row_pos"].to_numpy(dtype=int)
+            assigned = np.arange(len(g), dtype=int) % k
+            folds[row_pos] = assigned
+
+        if np.any(folds < 0):
+            raise RuntimeError("Fold assignment failed for one or more rows")
+        return folds
+
+    def _cross_fitted_residuals(self, df_train: pd.DataFrame) -> tuple[np.ndarray, np.ndarray]:
+        self._validate_columns(df_train)
+        n = len(df_train)
+        r_hat = np.full(n, np.nan, dtype=float)
+        u_hat = np.full(n, np.nan, dtype=float)
+
+        folds = self._assign_case_folds(df_train)
+        for fold_id in range(self.config.n_folds):
+            test_mask = folds == fold_id
+            if not np.any(test_mask):
+                continue
+
+            qm_fold = self._qmodel.fit_excluding(df_train, test_mask)
+            test_df = df_train.loc[test_mask]
+            test_positions = np.flatnonzero(test_mask)
+
+            surgeon_codes = test_df[Col.SURGEON_CODE].astype(str).to_numpy()
+            q_vals = np.array([self._get_ratio(s) for s in surgeon_codes], dtype=float)
+
+            preds = np.full(len(test_df), np.nan, dtype=float)
+            for q in np.unique(q_vals):
+                local_mask = q_vals == q
+                pred_local = qm_fold.predict(test_df.loc[local_mask], float(q))
+                preds[local_mask] = pred_local
+
+            r_hat[test_positions] = test_df[Col.BOOKED_MINUTES].to_numpy(dtype=float) - preds
+            u_hat[test_positions] = test_df[Col.PROCEDURE_DURATION].to_numpy(dtype=float) - preds
+
+        if np.isnan(r_hat).any() or np.isnan(u_hat).any():
+            warnings.warn("NaNs remain in cross-fitted residuals.", RuntimeWarning)
+
+        return r_hat, u_hat
+
+    def _build_residualized_pairs(
+        self, pairs: pd.DataFrame, r_hat: np.ndarray, u_hat: np.ndarray
+    ) -> pd.DataFrame:
+        if len(pairs) == 0:
+            return pd.DataFrame(columns=["surgeon_code", "service", "X", "Y"])
+
+        curr_idx = pairs["curr_idx"].to_numpy(dtype=int)
+        prev_idx = pairs["prev_idx"].to_numpy(dtype=int)
+
+        out = pd.DataFrame(
+            {
+                "surgeon_code": pairs["surgeon_code"].to_numpy(),
+                "service": pairs["service"].to_numpy(),
+                "X": u_hat[prev_idx],
+                "Y": r_hat[curr_idx] - r_hat[prev_idx],
+            }
+        )
+        return out.dropna().reset_index(drop=True)
+
+    def _profile_least_squares(self, X: np.ndarray, Y: np.ndarray) -> tuple[float, float, float, float]:
+        X = np.asarray(X, dtype=float)
+        Y = np.asarray(Y, dtype=float)
+
+        h_grid = np.arange(0.0, self.config.h_grid_max + self.config.h_grid_step, self.config.h_grid_step)
+        best = (self.config.a_min, 0.0, 0.0, np.inf)
+
+        for hp in h_grid:
+            for hm in h_grid:
+                Z = np.where(X < -hm, X + hm, np.where(X > hp, X - hp, 0.0))
+                denom = float(np.dot(Z, Z))
+                if denom <= 1e-12:
+                    a = self.config.a_min
+                else:
+                    a = float(np.dot(Y, Z) / denom)
+                a = float(np.clip(a, self.config.a_min, self.config.a_max))
+                resid = Y - a * Z
+                ssr = float(np.dot(resid, resid))
+                if ssr < best[3]:
+                    best = (a, float(hp), float(hm), ssr)
+
+        return best
+
+    def _completion_time(self, df: pd.DataFrame) -> pd.Series:
+        stop = pd.to_datetime(df[Col.ACTUAL_STOP], errors="coerce")
+        start = pd.to_datetime(df[Col.ACTUAL_START], errors="coerce")
+        return stop.fillna(start)
+
+    def _validate_columns(self, df: pd.DataFrame) -> None:
+        required = [
+            Col.SURGEON_CODE,
+            Col.PROCEDURE_ID,
+            Col.CASE_SERVICE,
+            Col.ACTUAL_START,
+            Col.ACTUAL_STOP,
+            Col.BOOKED_MINUTES,
+            Col.PROCEDURE_DURATION,
+        ]
+        missing = [c for c in required if c not in df.columns]
+        if missing:
+            raise ValueError(f"Missing required columns: {missing}")
+
+    def _get_ratio(self, surgeon_code: str) -> float:
+        if hasattr(self._critical, "get_ratio"):
+            return float(self._critical.get_ratio(surgeon_code))
+        if isinstance(self._critical, dict):
+            return float(self._critical.get(surgeon_code, self._critical.get(Domain.OTHER, 0.5)))
+        raise TypeError("critical_ratios must provide get_ratio or be a dict")
+
+    def _require_fitted(self) -> None:
+        if not self.is_fitted:
+            raise RuntimeError("ResponseEstimator must be fitted before access")

--- a/src/estimation/serialization.py
+++ b/src/estimation/serialization.py
@@ -1,0 +1,20 @@
+"""Persistence helpers for estimation artifacts."""
+
+from pathlib import Path
+
+import joblib
+
+DEFAULT_PATH = Path("outputs/estimation_artifacts.joblib")
+
+
+def save_estimation(result, path: Path = DEFAULT_PATH) -> Path:
+    """Persist estimation artifacts to disk using joblib."""
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    joblib.dump(result, output_path)
+    return output_path
+
+
+def load_estimation(path: Path = DEFAULT_PATH):
+    """Load persisted estimation artifacts from disk."""
+    return joblib.load(Path(path))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_estimation/test_inverse.py
+++ b/tests/test_estimation/test_inverse.py
@@ -1,0 +1,92 @@
+import numpy as np
+import pandas as pd
+
+from src.core.config import InverseConfig
+from src.core.types import Col, Domain
+from src.estimation.inverse import CriticalRatioEstimator
+
+
+class FakeQuantileModel:
+    def __init__(self) -> None:
+        self.grid = np.array([0.1, 0.5, 0.9])
+
+    def predict_grid(self, df: pd.DataFrame, q_grid=None):
+        grid = self.grid if q_grid is None else np.array(q_grid)
+        base = df["_base"].to_numpy(dtype=float)
+        return {float(q): base + 100.0 * (float(q) - 0.5) for q in grid}
+
+
+def _make_surgeon_rows(surgeon: str, service: str, n: int, q_true: float, base: float, seed: int):
+    rng = np.random.default_rng(seed)
+    base_vals = base + rng.normal(0.0, 3.0, size=n)
+    booked = base_vals + 100.0 * (q_true - 0.5)
+    return pd.DataFrame(
+        {
+            Col.SURGEON_CODE: surgeon,
+            Col.CASE_SERVICE: service,
+            Col.BOOKED_MINUTES: booked,
+            "_base": base_vals,
+        }
+    )
+
+
+def _fixture_df() -> pd.DataFrame:
+    parts = [
+        _make_surgeon_rows("A", "X", 60, 0.9, 120.0, 1),  # rich
+        _make_surgeon_rows("B", "X", 55, 0.5, 110.0, 2),  # rich
+        _make_surgeon_rows("C", "X", 12, 0.1, 105.0, 3),  # sparse >=10 pooled blend
+        _make_surgeon_rows("D", "Y", 8, 0.9, 130.0, 4),   # sparse <10 -> service/grand
+        _make_surgeon_rows(Domain.OTHER, "X", 6, 0.5, 115.0, 5),
+    ]
+    return pd.concat(parts, ignore_index=True)
+
+
+def _fit_estimator() -> CriticalRatioEstimator:
+    est = CriticalRatioEstimator(
+        quantile_model=FakeQuantileModel(),
+        config=InverseConfig(n_min=50, pooling_lambda=50.0),
+    )
+    return est.fit(_fixture_df())
+
+
+def test_all_ratios_returned():
+    df = _fixture_df()
+    est = _fit_estimator()
+    ratios = est.get_all_ratios()
+
+    expected = set(df[Col.SURGEON_CODE].unique()) | {Domain.OTHER}
+    assert expected.issubset(set(ratios.keys()))
+
+
+def test_ratios_in_unit_interval():
+    est = _fit_estimator()
+    ratios = est.get_all_ratios()
+    assert all(0.01 <= q <= 0.99 for q in ratios.values())
+
+
+def test_unknown_surgeon_falls_back_to_other():
+    est = _fit_estimator()
+    assert est.get_ratio("not-seen") == est.get_ratio(Domain.OTHER)
+
+
+def test_partial_pooling_for_sparse_surgeon():
+    est = _fit_estimator()
+
+    q_a = est.get_ratio("A")  # rich, should be individual near 0.9
+    q_b = est.get_ratio("B")  # rich, should be individual near 0.5
+    q_c = est.get_ratio("C")  # sparse pooled blend
+    q_d = est.get_ratio("D")  # sparse < 10 -> target
+
+    assert np.isclose(q_a, 0.9)
+    assert np.isclose(q_b, 0.5)
+    assert 0.1 < q_c < 0.9
+    assert q_d > 0.5
+
+
+def test_misalignment_formula():
+    est = _fit_estimator()
+    q_a = est.get_ratio("A")
+
+    co, cu = 2.0, 3.0
+    expected = q_a - (co / (co + cu))
+    assert np.isclose(est.get_misalignment("A", co=co, cu=cu), expected)

--- a/tests/test_estimation/test_profiles.py
+++ b/tests/test_estimation/test_profiles.py
@@ -1,0 +1,89 @@
+import numpy as np
+import pandas as pd
+
+from src.core.config import ProfileConfig
+from src.core.types import Domain
+from src.estimation.profiles import ResponseProfiler
+
+
+def _params_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "surgeon_code": ["S1", "S2", "S3", "S4", "S5", Domain.OTHER],
+            "a": [0.20, 0.22, 0.95, 0.40, 0.42, 0.30],
+            "h_plus": [10.0, 11.0, 120.0, 20.0, 19.0, 15.0],
+            "h_minus": [9.0, 10.0, 110.0, 18.0, 21.0, 15.0],
+            "is_individual": [True, True, False, True, True, False],
+        }
+    )
+
+
+def _services() -> dict[str, str]:
+    return {
+        "S1": "SvcA",
+        "S2": "SvcA",
+        "S3": "SvcA",  # pooled outlier in same service
+        "S4": "SvcB",
+        "S5": "SvcB",
+        Domain.OTHER: Domain.OTHER,
+    }
+
+
+def test_profiles_created():
+    profiler = ResponseProfiler(ProfileConfig(n_profiles_per_service=1)).fit(_params_df(), _services())
+
+    assert profiler.n_profiles >= 3
+    assert len(profiler.get_all_profiles()) == profiler.n_profiles
+
+
+def test_pooled_surgeons_mapped_after_clustering():
+    profiler = ResponseProfiler(ProfileConfig(n_profiles_per_service=1)).fit(_params_df(), _services())
+
+    p_s1 = profiler.get_profile("S1")
+    p_s3 = profiler.get_profile("S3")
+    assert p_s1.service == "SvcA"
+    assert p_s3.service == "SvcA"
+    assert p_s1.a < 0.5  # pooled outlier (S3) does not define service center
+
+
+def test_other_profile_exists():
+    profiler = ResponseProfiler(ProfileConfig(n_profiles_per_service=1)).fit(_params_df(), _services())
+    p_other = profiler.get_profile(Domain.OTHER)
+    assert p_other.service == Domain.OTHER
+
+
+def test_get_profile_id_unknown_returns_other():
+    profiler = ResponseProfiler(ProfileConfig(n_profiles_per_service=1)).fit(_params_df(), _services())
+    assert profiler.get_profile_id("unknown") == profiler.get_profile_id(Domain.OTHER)
+
+
+def test_sos2_knots_ordered():
+    profiler = ResponseProfiler(ProfileConfig(n_profiles_per_service=1)).fit(_params_df(), _services())
+    pid = profiler.get_profile_id("S1")
+    x, _ = profiler.get_sos2_knots(pid, L_ti=80.0, U_ti=220.0, b_ti=120.0)
+
+    assert np.all(np.diff(x) >= -1e-9)
+
+
+def test_sos2_values_match_piecewise_formula():
+    profiler = ResponseProfiler(ProfileConfig(n_profiles_per_service=1)).fit(_params_df(), _services())
+    pid = profiler.get_profile_id("S1")
+    p = profiler.get_profile("S1")
+
+    L_ti, U_ti, b_ti = 80.0, 220.0, 120.0
+    x, y = profiler.get_sos2_knots(pid, L_ti=L_ti, U_ti=U_ti, b_ti=b_ti)
+
+    hm = min(p.h_minus, max(0.0, b_ti - L_ti))
+    hp = min(p.h_plus, max(0.0, U_ti - b_ti))
+    expected = np.array(
+        [
+            p.a * ((L_ti - b_ti) + hm),
+            0.0,
+            0.0,
+            0.0,
+            p.a * ((U_ti - b_ti) - hp),
+        ]
+    )
+    assert np.allclose(y, expected)
+    assert np.isclose(x[1], -hm)
+    assert np.isclose(x[3], hp)

--- a/tests/test_estimation/test_quantile_model.py
+++ b/tests/test_estimation/test_quantile_model.py
@@ -1,0 +1,108 @@
+import numpy as np
+import pandas as pd
+
+from src.core.config import QuantileModelConfig
+from src.core.types import Col
+from src.estimation.quantile_model import ConditionalQuantileModel
+
+
+def _synthetic_df(n: int = 220, seed: int = 7) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    procedures = np.array(["P1", "P2", "P3", "P4"])
+    surgeons = np.array(["S1", "S2", "S3"])
+    services = np.array(["SvcA", "SvcB"])
+
+    proc = rng.choice(procedures, size=n, p=[0.4, 0.3, 0.2, 0.1])
+    surg = rng.choice(surgeons, size=n)
+    svc = rng.choice(services, size=n)
+    month = rng.integers(1, 13, size=n)
+
+    proc_effect = {"P1": 70, "P2": 110, "P3": 150, "P4": 220}
+    surg_effect = {"S1": -8, "S2": 0, "S3": 12}
+    svc_effect = {"SvcA": 0, "SvcB": 10}
+
+    duration = np.array([
+        proc_effect[p] + surg_effect[s] + svc_effect[v] + rng.normal(0, 18)
+        for p, s, v in zip(proc, surg, svc)
+    ])
+    duration = np.clip(duration, 30, 500)
+
+    return pd.DataFrame(
+        {
+            Col.PROCEDURE_ID: proc,
+            Col.SURGEON_CODE: surg,
+            Col.CASE_SERVICE: svc,
+            Col.MONTH: month,
+            Col.PROCEDURE_DURATION: duration,
+            Col.BOOKED_MINUTES: duration + rng.normal(0, 15, size=n),
+        }
+    )
+
+
+def test_fit_and_predict_shapes():
+    df = _synthetic_df()
+    model = ConditionalQuantileModel(QuantileModelConfig(q_grid_size=15)).fit(df)
+    preds = model.predict(df.head(25), q=0.5)
+
+    assert model.is_fitted
+    assert preds.shape == (25,)
+    assert np.isfinite(preds).all()
+
+
+def test_predict_grid_keys():
+    df = _synthetic_df()
+    model = ConditionalQuantileModel(QuantileModelConfig(q_grid_size=9)).fit(df)
+    grid = np.array([0.1, 0.5, 0.9])
+    pred_map = model.predict_grid(df.head(10), q_grid=grid)
+
+    expected_keys = {model._snap_quantile(q) for q in grid}
+    assert set(pred_map.keys()) == expected_keys
+    for arr in pred_map.values():
+        assert arr.shape == (10,)
+
+
+def test_fit_excluding_returns_new_model():
+    df = _synthetic_df()
+    model = ConditionalQuantileModel(QuantileModelConfig(q_grid_size=7)).fit(df)
+    original_models_id = id(model._models)
+
+    exclude_mask = np.zeros(len(df), dtype=bool)
+    exclude_mask[:20] = True
+    new_model = model.fit_excluding(df, exclude_mask)
+
+    assert new_model is not model
+    assert new_model.is_fitted
+    assert model.is_fitted
+    assert id(model._models) == original_models_id
+
+
+def test_no_booked_time_in_features():
+    df = _synthetic_df()
+    model = ConditionalQuantileModel(QuantileModelConfig(q_grid_size=5)).fit(df)
+
+    names = model._preprocessor.get_feature_names_out().tolist()
+    assert all("booked" not in name.lower() for name in names)
+    assert Col.BOOKED_MINUTES not in model.feature_columns
+
+
+def test_predictions_are_clipped():
+    df = _synthetic_df()
+    df.loc[:15, Col.PROCEDURE_DURATION] = 5000.0
+    model = ConditionalQuantileModel(QuantileModelConfig(q_grid_size=11)).fit(df)
+
+    preds = model.predict(df, q=0.99)
+    assert (preds >= 30.0).all()
+    assert (preds <= 1440.0).all()
+
+
+def test_quantile_monotonicity_on_sample():
+    df = _synthetic_df(n=260)
+    model = ConditionalQuantileModel(QuantileModelConfig(q_grid_size=21)).fit(df)
+
+    sample = df.sample(40, random_state=2)
+    p10 = model.predict(sample, q=0.10)
+    p50 = model.predict(sample, q=0.50)
+    p90 = model.predict(sample, q=0.90)
+
+    gross_violations = np.mean((p50 < p10 - 5.0) | (p90 < p50 - 5.0))
+    assert gross_violations < 0.2

--- a/tests/test_estimation/test_response_fit.py
+++ b/tests/test_estimation/test_response_fit.py
@@ -1,0 +1,137 @@
+import numpy as np
+import pandas as pd
+
+from src.core.config import ResponseConfig
+from src.core.types import Col, Domain
+from src.estimation.response import ResponseEstimator
+
+
+class DummyCriticalRatioEstimator:
+    def __init__(self, mapping: dict[str, float]):
+        self.mapping = mapping
+
+    def get_ratio(self, surgeon_code: str) -> float:
+        return self.mapping.get(surgeon_code, self.mapping.get(Domain.OTHER, 0.5))
+
+
+class MeanFoldModel:
+    def __init__(self, train_mean: float):
+        self.train_mean = train_mean
+
+    def predict(self, df: pd.DataFrame, q: float) -> np.ndarray:
+        return np.full(len(df), self.train_mean + 15.0 * (q - 0.5), dtype=float)
+
+
+class MeanExcludingQuantileModel:
+    def fit_excluding(self, df: pd.DataFrame, exclude_mask: np.ndarray):
+        mask = np.asarray(exclude_mask, dtype=bool)
+        train_mean = float(df.loc[~mask, Col.PROCEDURE_DURATION].mean())
+        return MeanFoldModel(train_mean)
+
+
+def _make_rows(surgeon: str, service: str, n: int, base: float, q: float, start_day: int):
+    t0 = pd.Timestamp("2025-01-01") + pd.Timedelta(days=start_day)
+    times = [t0 + pd.Timedelta(days=i) for i in range(n)]
+    idx = np.arange(n, dtype=float)
+    duration = base + 8.0 * np.sin(idx / 3.0)
+    booked = duration + 15.0 * (q - 0.5) + 2.0 * np.cos(idx / 4.0)
+    return pd.DataFrame(
+        {
+            Col.SURGEON_CODE: surgeon,
+            Col.PROCEDURE_ID: ["P1"] * n,
+            Col.CASE_SERVICE: [service] * n,
+            Col.ACTUAL_START: times,
+            Col.ACTUAL_STOP: [t + pd.Timedelta(hours=2) for t in times],
+            Col.PROCEDURE_DURATION: duration,
+            Col.BOOKED_MINUTES: booked,
+        }
+    )
+
+
+def _training_df() -> pd.DataFrame:
+    parts = [
+        _make_rows("S1", "SvcA", 24, 120.0, 0.9, 0),
+        _make_rows("S2", "SvcA", 22, 130.0, 0.4, 30),
+        _make_rows("S3", "SvcA", 6, 118.0, 0.6, 80),
+        _make_rows("S5", "SvcA", 7, 122.0, 0.7, 95),
+        _make_rows("S4", "SvcB", 20, 150.0, 0.5, 120),
+        _make_rows(Domain.OTHER, "SvcA", 5, 125.0, 0.5, 170),
+    ]
+    return pd.concat(parts, ignore_index=True)
+
+
+def _fit_estimator() -> ResponseEstimator:
+    q_model = MeanExcludingQuantileModel()
+    critical = DummyCriticalRatioEstimator(
+        {"S1": 0.9, "S2": 0.4, "S3": 0.6, "S4": 0.5, "S5": 0.7, Domain.OTHER: 0.5}
+    )
+    config = ResponseConfig(
+        n_folds=3,
+        min_pairs=10,
+        h_grid_max=20.0,
+        h_grid_step=5.0,
+        a_min=0.01,
+        a_max=1.0,
+        delta_max_days=60,
+    )
+    return ResponseEstimator(q_model, critical, config).fit(_training_df())
+
+
+def test_profile_least_squares_returns_valid_range():
+    est = _fit_estimator()
+    X = np.array([-20.0, -5.0, 0.0, 5.0, 20.0])
+    Y = np.array([-10.0, -2.0, 0.0, 3.0, 9.0])
+
+    a, hp, hm, ssr = est._profile_least_squares(X, Y)
+
+    assert 0.01 <= a <= 1.0
+    assert hp >= 0.0
+    assert hm >= 0.0
+    assert ssr >= 0.0
+
+
+def test_response_fit_returns_params_for_all_surgeons():
+    df = _training_df()
+    est = _fit_estimator()
+
+    surgeons = set(df[Col.SURGEON_CODE].unique()) | {Domain.OTHER}
+    params = est.get_all_params()
+    assert surgeons.issubset(set(params["surgeon_code"]))
+
+
+def test_sparse_surgeons_are_pooled():
+    est = _fit_estimator()
+    p3 = est.get_params("S3")
+    p5 = est.get_params("S5")
+
+    assert not p3.is_individual
+    assert not p5.is_individual
+    assert np.isclose(p3.a, p5.a)
+    assert np.isclose(p3.h_plus, p5.h_plus)
+    assert np.isclose(p3.h_minus, p5.h_minus)
+
+
+def test_other_has_fallback_params():
+    est = _fit_estimator()
+    p_other = est.get_params(Domain.OTHER)
+
+    assert p_other.surgeon_code == Domain.OTHER
+    assert not p_other.is_individual
+    assert 0.01 <= p_other.a <= 1.0
+
+
+def test_get_all_params_dataframe_columns():
+    est = _fit_estimator()
+    df_params = est.get_all_params()
+
+    expected_cols = {"surgeon_code", "a", "h_plus", "h_minus", "n_pairs", "is_individual"}
+    assert expected_cols.issubset(set(df_params.columns))
+
+
+def test_acceptance_weights_in_range():
+    est = _fit_estimator()
+    params = est.get_all_params()
+
+    assert (params["a"] > 0.0).all()
+    assert (params["a"] <= 1.0).all()
+

--- a/tests/test_estimation/test_response_prep.py
+++ b/tests/test_estimation/test_response_prep.py
@@ -1,0 +1,120 @@
+import numpy as np
+import pandas as pd
+
+from src.core.config import ResponseConfig
+from src.core.types import Col, Domain
+from src.estimation.response import ResponseEstimator
+
+
+class DummyCriticalRatioEstimator:
+    def __init__(self, mapping: dict[str, float]):
+        self.mapping = mapping
+
+    def get_ratio(self, surgeon_code: str) -> float:
+        return self.mapping.get(surgeon_code, self.mapping.get(Domain.OTHER, 0.5))
+
+
+class SpyFoldModel:
+    def __init__(self, train_mean: float):
+        self.train_mean = train_mean
+
+    def predict(self, df: pd.DataFrame, q: float) -> np.ndarray:
+        return np.full(len(df), self.train_mean + q, dtype=float)
+
+
+class SpyQuantileModel:
+    def __init__(self):
+        self.exclude_masks: list[np.ndarray] = []
+
+    def fit_excluding(self, df: pd.DataFrame, exclude_mask: np.ndarray):
+        mask = np.asarray(exclude_mask, dtype=bool)
+        self.exclude_masks.append(mask.copy())
+        train_mean = float(df.loc[~mask, Col.PROCEDURE_DURATION].mean())
+        return SpyFoldModel(train_mean)
+
+
+def _make_df() -> pd.DataFrame:
+    times = pd.date_range("2025-01-01", periods=12, freq="D")
+    return pd.DataFrame(
+        {
+            Col.SURGEON_CODE: ["S1", "S1", "S1", "S2", "S2", "S2", "S3", "S3", "S3", Domain.OTHER, "S1", "S2"],
+            Col.PROCEDURE_ID: ["P1", "P1", "P2", "P1", "P1", Domain.OTHER, "P1", "P1", "P2", "P1", "P1", "P1"],
+            Col.CASE_SERVICE: ["SvcA", "SvcA", "SvcA", "SvcB", "SvcB", "SvcB", "SvcC", "SvcC", "SvcC", "SvcA", "SvcA", "SvcB"],
+            Col.ACTUAL_START: times,
+            Col.ACTUAL_STOP: times + pd.to_timedelta(2, unit="h"),
+            Col.BOOKED_MINUTES: np.linspace(60, 180, 12),
+            Col.PROCEDURE_DURATION: np.linspace(55, 170, 12),
+        }
+    )
+
+
+def _make_estimator(n_folds: int = 3):
+    qmodel = SpyQuantileModel()
+    critical = DummyCriticalRatioEstimator({"S1": 0.9, "S2": 0.5, "S3": 0.1, Domain.OTHER: 0.5})
+    est = ResponseEstimator(qmodel, critical, ResponseConfig(n_folds=n_folds, delta_max_days=60))
+    return est, qmodel
+
+
+def test_pair_builder_creates_expected_columns():
+    df = _make_df()
+    est, _ = _make_estimator()
+    pairs = est._build_consecutive_pairs(df)
+
+    assert list(pairs.columns) == ["surgeon_code", "service", "curr_idx", "prev_idx", "gap_days"]
+    assert len(pairs) > 0
+
+
+def test_pair_builder_excludes_other():
+    df = _make_df()
+    est, _ = _make_estimator()
+    pairs = est._build_consecutive_pairs(df)
+
+    assert (pairs["surgeon_code"] != Domain.OTHER).all()
+
+
+def test_fold_assignment_complete():
+    df = _make_df()
+    est, _ = _make_estimator(n_folds=4)
+    folds = est._assign_case_folds(df)
+
+    assert folds.shape == (len(df),)
+    assert set(folds.tolist()).issubset({0, 1, 2, 3})
+    assert np.all(folds >= 0)
+
+
+def test_cross_fitted_residuals_shape():
+    df = _make_df()
+    est, _ = _make_estimator(n_folds=3)
+    r_hat, u_hat = est._cross_fitted_residuals(df)
+
+    assert r_hat.shape == (len(df),)
+    assert u_hat.shape == (len(df),)
+
+
+def test_cross_fitted_residuals_have_few_or_no_nans():
+    df = _make_df()
+    est, _ = _make_estimator(n_folds=3)
+    r_hat, u_hat = est._cross_fitted_residuals(df)
+
+    assert np.isnan(r_hat).sum() == 0
+    assert np.isnan(u_hat).sum() == 0
+
+
+def test_each_case_predicted_out_of_fold():
+    df = _make_df()
+    est, qmodel = _make_estimator(n_folds=3)
+
+    folds = est._assign_case_folds(df)
+    r_hat, _ = est._cross_fitted_residuals(df)
+
+    assert len(qmodel.exclude_masks) == 3
+    for fold_id, mask in enumerate(qmodel.exclude_masks):
+        expected_mask = folds == fold_id
+        assert np.array_equal(mask, expected_mask)
+
+    pred = df[Col.BOOKED_MINUTES].to_numpy(dtype=float) - r_hat
+    for i in range(len(df)):
+        fold_id = folds[i]
+        train_mean = float(df.loc[folds != fold_id, Col.PROCEDURE_DURATION].mean())
+        q = est._critical.get_ratio(df.loc[i, Col.SURGEON_CODE])
+        assert np.isclose(pred[i], train_mean + q)


### PR DESCRIPTION
### Motivation

- Introduce a self-contained estimation pipeline for surgery-duration quantile modeling and behavioral response estimation to support downstream optimization and diagnostics.
- Provide persistence and a simple CLI entrypoint for running estimation artifacts.
- Expose tunable estimation parameters in the central `Config` to make experiments reproducible and configurable.

### Description

- Add a new `src/estimation` package implementing a conditional quantile model (`ConditionalQuantileModel`), critical-ratio inverse estimator (`CriticalRatioEstimator`), response data preparation and fitting utilities (`ResponseEstimator`), profile clustering and SOS2 knot generation (`ResponseProfiler`), and artifact serialization helpers (`serialization.py`).
- Add `src/estimation/__init__.py` to hold shared `EstimationResult` typing and `src/diagnostics/__init__.py` as a placeholder diagnostics package.
- Add a CLI script `scripts/run_estimation.py` (parser skeleton) and persistence helpers using `joblib` with `DEFAULT_PATH = outputs/estimation_artifacts.joblib`.
- Extend `src/core/config.py` with new dataclasses `QuantileModelConfig`, `InverseConfig`, `ResponseConfig`, `ProfileConfig`, `BootstrapConfig`, and aggregate them into `EstimationConfig` referenced from `Config`.
- Add `joblib` to `pyproject.toml` dependencies and include comprehensive unit tests under `tests/test_estimation/*` plus `tests/conftest.py` covering the quantile model, inverse estimator, response preparer/fit, and profiling logic.

### Testing

- Ran the new unit test suite with `pytest tests/test_estimation -q` covering `test_quantile_model.py`, `test_inverse.py`, `test_response_prep.py`, `test_response_fit.py`, and `test_profiles.py`, and all tests completed successfully.
- The tests exercise fit/predict paths for the quantile model, cross-fold residual computations and pair building in `ResponseEstimator`, profile clustering and SOS2 knot outputs in `ResponseProfiler`, and partial pooling logic in `CriticalRatioEstimator`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c432c2ae5c832b8e534ac64ec055ad)