### PR TITLE
Add Piece 1 VFCG package scaffolding and config wiring

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Tuple
 
 from src.bilevel.config import LegacyCCGConfig
+from src.vfcg.config import VFCGConfig
 
 
 @dataclass
@@ -127,3 +128,4 @@ class Config:
     scope: ExperimentScopeConfig = field(default_factory=ExperimentScopeConfig)
     estimation: EstimationConfig = field(default_factory=EstimationConfig)
     legacy_ccg: LegacyCCGConfig = field(default_factory=LegacyCCGConfig)
+    vfcg: VFCGConfig = field(default_factory=VFCGConfig)

--- a/src/methods/vfcg.py
+++ b/src/methods/vfcg.py
@@ -1,0 +1,22 @@
+"""Exact VFCG method (piece 1 stub)."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from src.core.config import Config
+from src.core.types import ScheduleResult, WeeklyInstance
+from src.methods.base import Method
+
+
+class VFCGMethod(Method):
+    def __init__(self, config: Config):
+        super().__init__(name="VFCG", config=config)
+
+    def fit(self, df_train: pd.DataFrame) -> None:
+        _ = df_train
+        raise NotImplementedError("VFCGMethod.fit is not implemented in piece 1.")
+
+    def plan(self, instance: WeeklyInstance) -> ScheduleResult:
+        _ = instance
+        raise NotImplementedError("VFCGMethod.plan is not implemented in piece 1.")

--- a/src/vfcg/__init__.py
+++ b/src/vfcg/__init__.py
@@ -1,0 +1,5 @@
+"""Exact VFCG stack (piece 1 scaffolding)."""
+
+from src.vfcg.config import VFCGConfig
+
+__all__ = ["VFCGConfig"]

--- a/src/vfcg/certify.py
+++ b/src/vfcg/certify.py
@@ -1,0 +1,1 @@
+"""VFCG scaffolding module for piece 1."""

--- a/src/vfcg/config.py
+++ b/src/vfcg/config.py
@@ -1,0 +1,21 @@
+"""Configuration for the exact VFCG stack."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class VFCGConfig:
+    w_max: float = 10.0
+    credibility_eta: float = 1.05
+    plausibility_tau_L: float = 0.01
+    plausibility_tau_U: float = 0.99
+    max_iterations: int = 50
+    convergence_tol: float = 1e-4
+    master_time_limit: int = 1800
+    master_mip_gap: float = 0.01
+    oracle_time_limit: int = 300
+    certification_tol: float = 1e-6
+    n_warmstart_vectors: int = 3
+    max_training_weeks: int | None = 20

--- a/src/vfcg/cuts.py
+++ b/src/vfcg/cuts.py
@@ -1,0 +1,1 @@
+"""VFCG scaffolding module for piece 1."""

--- a/src/vfcg/diagnostics.py
+++ b/src/vfcg/diagnostics.py
@@ -1,0 +1,1 @@
+"""VFCG scaffolding module for piece 1."""

--- a/src/vfcg/init.py
+++ b/src/vfcg/init.py
@@ -1,0 +1,1 @@
+"""Compatibility module for requested vfcg init file."""

--- a/src/vfcg/master.py
+++ b/src/vfcg/master.py
@@ -1,0 +1,1 @@
+"""VFCG scaffolding module for piece 1."""

--- a/src/vfcg/oracle.py
+++ b/src/vfcg/oracle.py
@@ -1,0 +1,1 @@
+"""VFCG scaffolding module for piece 1."""

--- a/src/vfcg/solver.py
+++ b/src/vfcg/solver.py
@@ -1,0 +1,1 @@
+"""VFCG scaffolding module for piece 1."""

--- a/src/vfcg/types.py
+++ b/src/vfcg/types.py
@@ -1,0 +1,51 @@
+"""Typed result containers for exact VFCG components."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from src.core.column import ScheduleColumn
+
+
+@dataclass
+class OracleResult:
+    schedule: ScheduleColumn
+    predicted_cost: float
+    realized_cost: float
+    status: str
+    solve_time: float
+
+
+@dataclass
+class VFCGIteration:
+    iteration_index: int
+    master_status: str
+    master_objective: float
+    master_bound: float
+    master_gap: float
+    n_reference_cuts: int
+    n_violated_weeks: int
+    master_solve_time: float
+    oracle_solve_time_total: float
+
+
+@dataclass
+class CertificationResult:
+    status: str
+    max_violation: float
+    reconstructed_objective: float
+    master_objective: float
+    master_bound: float
+    tie_break_flags: list[str] | None = None
+
+
+@dataclass
+class VFCGResult:
+    w_optimal: np.ndarray
+    objective: float
+    n_iterations: int
+    certification: CertificationResult
+    iterations: list[VFCGIteration]
+    total_cuts_added: int

--- a/src/vfcg/warmstart.py
+++ b/src/vfcg/warmstart.py
@@ -1,0 +1,1 @@
+"""VFCG scaffolding module for piece 1."""

--- a/tests/test_vfcg/test_certify.py
+++ b/tests/test_vfcg/test_certify.py
@@ -1,0 +1,5 @@
+"""Piece-1 placeholder tests for vfcg modules."""
+
+
+def test_module_placeholder() -> None:
+    assert True

--- a/tests/test_vfcg/test_cuts.py
+++ b/tests/test_vfcg/test_cuts.py
@@ -1,0 +1,5 @@
+"""Piece-1 placeholder tests for vfcg modules."""
+
+
+def test_module_placeholder() -> None:
+    assert True

--- a/tests/test_vfcg/test_master.py
+++ b/tests/test_vfcg/test_master.py
@@ -1,0 +1,5 @@
+"""Piece-1 placeholder tests for vfcg modules."""
+
+
+def test_module_placeholder() -> None:
+    assert True

--- a/tests/test_vfcg/test_method_integration.py
+++ b/tests/test_vfcg/test_method_integration.py
@@ -1,0 +1,14 @@
+from src.core.config import Config
+
+
+def test_config_exposes_legacy_and_vfcg_configs() -> None:
+    config = Config()
+
+    assert hasattr(config, "legacy_ccg")
+    assert hasattr(config, "vfcg")
+
+
+def test_import_src_vfcg_package() -> None:
+    import src.vfcg as vfcg
+
+    assert vfcg is not None

--- a/tests/test_vfcg/test_oracle.py
+++ b/tests/test_vfcg/test_oracle.py
@@ -1,0 +1,5 @@
+"""Piece-1 placeholder tests for vfcg modules."""
+
+
+def test_module_placeholder() -> None:
+    assert True

--- a/tests/test_vfcg/test_solver.py
+++ b/tests/test_vfcg/test_solver.py
@@ -1,0 +1,5 @@
+"""Piece-1 placeholder tests for vfcg modules."""
+
+
+def test_module_placeholder() -> None:
+    assert True

--- a/tests/test_vfcg/test_warmstart.py
+++ b/tests/test_vfcg/test_warmstart.py
@@ -1,0 +1,5 @@
+"""Piece-1 placeholder tests for vfcg modules."""
+
+
+def test_module_placeholder() -> None:
+    assert True


### PR DESCRIPTION
### Motivation
- Provide the repository-level scaffolding and configuration entrypoint for the exact VFCG stack so the project can import and run while the algorithmic pieces are developed incrementally.
- Keep the existing legacy heuristic stack intact and accessible while adding the new `vfcg` path side-by-side for a smooth integration path.
- Ensure initial unit tests and import-smoke checks exist so future pieces can be built with confidence that the new package and config do not break the repo.

### Description
- Added a new package `src/vfcg/` with placeholder modules: `__init__.py`, `init.py`, and scaffolding modules `oracle.py`, `warmstart.py`, `cuts.py`, `master.py`, `solver.py`, `certify.py`, and `diagnostics.py` (placeholders only in Piece 1). Files created under `src/vfcg/` contain module stubs and a minimal export surface.
- Implemented `VFCGConfig` in `src/vfcg/config.py` with the requested defaults and fields, including `max_training_weeks: int | None = 20` and other tuning/limit fields.
- Added typed dataclasses in `src/vfcg/types.py`: `OracleResult`, `VFCGIteration`, `CertificationResult`, and `VFCGResult` with the specified fields and types to serve as result containers for future components.
- Wired the new config into the global application config by adding `vfcg: VFCGConfig` to `Config` in `src/core/config.py` while preserving the existing `legacy_ccg` field unchanged.
- Added a `VFCGMethod` stub in `src/methods/vfcg.py` implementing the `Method` interface with `fit` and `plan` that currently raise `NotImplementedError` (intentional for Piece 1).
- Created initial test scaffold under `tests/test_vfcg/`, including a smoke integration test that verifies `Config` exposes both `legacy_ccg` and `vfcg` and that `src.vfcg` is importable; also added placeholder module tests to establish the requested test layout.
- Resolved an import-order/circular-import issue by keeping `src/vfcg.__init__` minimal (exporting only `VFCGConfig`) to avoid import cycles during test collection.
- No algorithmic or bilevel logic was implemented and no code from `src/bilevel/` was reused in the new `vfcg` path.

### Testing
- Ran the new VFCG-targeted tests under `tests/test_vfcg/` with `pytest` and verified all tests passed (8 passed).
- Executed the smoke integration test that constructs `Config()` and imports `src.vfcg`; the import and attribute checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc09ed81c8832b8de00ea30a018888)