### PR TITLE
Fix VFCG fallback semantics and warmstart truncation

### DIFF
--- a/src/vfcg/master.py
+++ b/src/vfcg/master.py
@@ -13,8 +13,9 @@ from gurobipy import GRB, quicksum
 from src.core.column import ScheduleColumn, extract_column_from_model
 from src.core.config import CapacityConfig, Config, CostConfig, SolverConfig
 from src.estimation.recommendation import RecommendationModel, WeekRecommendationData
-from src.solvers.deterministic import solve_pricing
+from src.solvers.deterministic import solve_weekly_optimistic
 from src.vfcg.cuts import add_reference_predicted_cost_rhs
+from src.vfcg.oracle import build_case_records_from_week_data
 
 logger = logging.getLogger(__name__)
 
@@ -208,28 +209,38 @@ def solve_native_master(
         weights = np.zeros(feat_dim, dtype=float)
         schedules: dict[int, ScheduleColumn] = {}
         pred_costs: dict[int, float] = {}
+        fallback_realized_costs: list[float] = []
         for wd in week_data_list:
-            col, obj_val = solve_pricing(
-                n_cases=wd.n_cases,
-                durations=np.asarray(wd.bookings, dtype=float),
+            cases = build_case_records_from_week_data(wd)
+            planning_durations = np.asarray(wd.bookings, dtype=float)
+            realized_durations = np.asarray(wd.realized, dtype=float)
+            col, predicted_cost, _, fallback_status, _ = solve_weekly_optimistic(
+                cases=cases,
+                planning_durations=planning_durations,
+                realized_durations=realized_durations,
                 calendar=wd.calendar,
                 costs=costs,
                 solver_cfg=solver_cfg,
                 case_eligible_blocks=wd.case_eligible_blocks,
                 turnover=turnover,
                 model_name=f"fallback_week_{wd.week_index}",
+                tol=config.vfcg.convergence_tol or 1e-6,
             )
             if col is None:
-                raise RuntimeError(f"Fallback pricing failed for week {wd.week_index}")
-            schedules[int(wd.week_index)] = col
-            pred_costs[int(wd.week_index)] = float(obj_val)
+                raise RuntimeError(f"Fallback optimistic solve failed for week {wd.week_index} (status={fallback_status})")
+            week_key = int(wd.week_index)
+            schedules[week_key] = col
+            pred_costs[week_key] = float(predicted_cost)
+            fallback_realized_costs.append(float(col.compute_cost(realized_durations, costs, turnover)))
+
+        fallback_objective = float(np.mean(fallback_realized_costs)) if fallback_realized_costs else float("inf")
 
         return NativeMasterResult(
             weights=weights,
             schedules_by_week=schedules,
-            objective=float("inf"),
-            bound=float("inf"),
-            gap=float("inf"),
+            objective=fallback_objective,
+            bound=fallback_objective,
+            gap=float("nan"),
             solve_time=time.perf_counter() - t0,
             status=f"{status_name}_FALLBACK",
             predicted_costs_by_week=pred_costs,

--- a/src/vfcg/oracle.py
+++ b/src/vfcg/oracle.py
@@ -13,6 +13,27 @@ from src.solvers.deterministic import solve_weekly_optimistic
 from src.vfcg.types import OracleResult
 
 
+def build_case_records_from_week_data(week_data: WeekRecommendationData) -> list[CaseRecord]:
+    realized = np.asarray(week_data.realized, dtype=float)
+    return [
+        CaseRecord(
+            case_id=i,
+            procedure_id="UNK",
+            surgeon_code=week_data.surgeon_codes[i] if i < len(week_data.surgeon_codes) else "UNK",
+            service="Other",
+            patient_type="Elective",
+            operating_room="",
+            booked_duration_min=float(week_data.bookings[i]),
+            actual_duration_min=float(realized[i]),
+            actual_start=datetime(2020, 1, 1),
+            week_of_year=1,
+            month=1,
+            year=2020,
+        )
+        for i in range(week_data.n_cases)
+    ]
+
+
 class ExactFollowerOracle:
     """Single authoritative follower oracle using the compact weekly MIP."""
 
@@ -32,23 +53,7 @@ class ExactFollowerOracle:
         d_post = np.asarray(recommendation_model.compute_post_review(w, week_data), dtype=float)
         realized = np.asarray(week_data.realized, dtype=float)
 
-        cases = [
-            CaseRecord(
-                case_id=i,
-                procedure_id="UNK",
-                surgeon_code=week_data.surgeon_codes[i] if i < len(week_data.surgeon_codes) else "UNK",
-                service="Other",
-                patient_type="Elective",
-                operating_room="",
-                booked_duration_min=float(week_data.bookings[i]),
-                actual_duration_min=float(realized[i]),
-                actual_start=datetime(2020, 1, 1),
-                week_of_year=1,
-                month=1,
-                year=2020,
-            )
-            for i in range(week_data.n_cases)
-        ]
+        cases = build_case_records_from_week_data(week_data)
 
         schedule, predicted_cost, realized_cost, status, solve_time = solve_weekly_optimistic(
             cases=cases,

--- a/src/vfcg/solver.py
+++ b/src/vfcg/solver.py
@@ -12,7 +12,7 @@ from src.vfcg.certify import certify
 from src.vfcg.diagnostics import log_iteration_summary
 from src.vfcg.master import solve_native_master
 from src.vfcg.oracle import ExactFollowerOracle
-from src.vfcg.types import VFCGIteration, VFCGResult
+from src.vfcg.types import CertificationResult, VFCGIteration, VFCGResult
 from src.vfcg.warmstart import generate_warmstart_references
 
 logger = logging.getLogger(__name__)
@@ -130,6 +130,19 @@ def vfcg_solve(
         master_bound=final_master.bound,
         weekly_schedules=final_master.schedules_by_week,
     )
+
+    if final_master.is_fallback:
+        tie_break_flags = list(certification.tie_break_flags or [])
+        if "master_fallback_used" not in tie_break_flags:
+            tie_break_flags.append("master_fallback_used")
+        certification = CertificationResult(
+            status="TERMINATED_UNVERIFIED",
+            max_violation=certification.max_violation,
+            reconstructed_objective=certification.reconstructed_objective,
+            master_objective=certification.master_objective,
+            master_bound=certification.master_bound,
+            tie_break_flags=tie_break_flags,
+        )
 
     return VFCGResult(
         w_optimal=np.asarray(final_master.weights, dtype=float),

--- a/src/vfcg/warmstart.py
+++ b/src/vfcg/warmstart.py
@@ -86,11 +86,4 @@ def generate_warmstart_references(
 
         references[int(week_data.week_index)] = deduped
 
-    max_training_weeks = getattr(capacity_cfg, "max_training_weeks", None)
-    if max_training_weeks is not None:
-        nonempty_items = [(widx, cols) for widx, cols in references.items() if cols]
-        nonempty_items.sort(key=lambda x: x[0])
-        kept = nonempty_items[-int(max_training_weeks) :]
-        references = {widx: cols for widx, cols in kept}
-
     return references

--- a/tests/test_vfcg/test_master.py
+++ b/tests/test_vfcg/test_master.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from src.core.column import ScheduleColumn
 from src.core.config import CapacityConfig, Config, CostConfig, SolverConfig
 from src.core.types import BlockCalendar, CandidateBlock
 from src.estimation.recommendation import SOS2CaseData, WeekRecommendationData
@@ -43,6 +44,18 @@ def _config() -> Config:
     cfg.vfcg.master_mip_gap = 0.0
     cfg.vfcg.w_max = 10.0
     return cfg
+
+
+def _column(block: CandidateBlock) -> ScheduleColumn:
+    return ScheduleColumn(
+        z_assign={(0, block.id): 1.0},
+        z_defer=frozenset({1}),
+        v_open=frozenset({block.id}),
+        y_used=frozenset({block.id}),
+        n_cases=2,
+        block_capacities={block.id: block.capacity_minutes},
+        block_activation_costs={block.id: block.activation_cost},
+    )
 
 
 def test_empty_reference_sets_produce_solveable_relaxation() -> None:
@@ -119,3 +132,36 @@ def test_eligible_pair_sparsity_respected_in_extraction() -> None:
 
     col = res.schedules_by_week[0]
     assert all(bid != b2.id for (_, bid) in col.z_assign.keys())
+
+
+def test_native_master_fallback_returns_finite_values_and_uses_optimistic_solver(monkeypatch) -> None:
+    wd = _week()
+    cfg = _config()
+    cfg.vfcg.credibility_eta = -1.0
+
+    def _fake_solve_weekly_optimistic(**kwargs):
+        calendar = kwargs["calendar"]
+        return _column(calendar.candidates[0]), 12.5, 13.0, "OPTIMAL", 0.01
+
+    monkeypatch.setattr("src.vfcg.master.solve_weekly_optimistic", _fake_solve_weekly_optimistic)
+
+    def _raise_if_called(**_kwargs):
+        raise AssertionError("solve_pricing should not be used in fallback")
+
+    monkeypatch.setattr("src.vfcg.master.solve_pricing", _raise_if_called, raising=False)
+
+    res = solve_native_master(
+        week_data_list=[wd],
+        reference_sets={},
+        recommendation_model=_DummyRecommendation(),
+        config=cfg,
+        costs=CostConfig(),
+        capacity_cfg=CapacityConfig(),
+        solver_cfg=SolverConfig(time_limit_seconds=30, mip_gap=0.0, verbose=False),
+        turnover=0.0,
+    )
+
+    assert res.is_fallback is True
+    assert np.isfinite(res.objective)
+    assert np.isfinite(res.bound)
+    assert res.status.endswith("_FALLBACK")

--- a/tests/test_vfcg/test_solver.py
+++ b/tests/test_vfcg/test_solver.py
@@ -178,3 +178,34 @@ def test_fallback_path_goes_directly_to_certification(monkeypatch) -> None:
     res = vfcg_solve([wd], _Rec(), _cfg(), CostConfig(), CapacityConfig(), SolverConfig(), 0.0)
     assert marker["called"] == 1
     assert res.n_iterations == 1
+
+
+def test_vfcg_solver_downgrades_fallback_certification_status(monkeypatch) -> None:
+    wd = _week()
+    col = _col()
+
+    monkeypatch.setattr("src.vfcg.solver.generate_warmstart_references", lambda **kwargs: {0: [col]})
+    monkeypatch.setattr(
+        "src.vfcg.solver.solve_native_master",
+        lambda **kwargs: NativeMasterResult(
+            weights=np.array([0.0]),
+            schedules_by_week={0: col},
+            objective=10.0,
+            bound=10.0,
+            gap=float("nan"),
+            solve_time=0.1,
+            status="TIME_LIMIT_FALLBACK",
+            predicted_costs_by_week={0: 10.0},
+            is_fallback=True,
+        ),
+    )
+    monkeypatch.setattr("src.vfcg.solver.ExactFollowerOracle", lambda: object())
+    monkeypatch.setattr(
+        "src.vfcg.solver.certify",
+        lambda **kwargs: CertificationResult("OPTIMAL_VERIFIED", 0.0, 10.0, 10.0, 10.0, None),
+    )
+
+    res = vfcg_solve([wd], _Rec(), _cfg(), CostConfig(), CapacityConfig(), SolverConfig(), 0.0)
+
+    assert res.certification.status == "TERMINATED_UNVERIFIED"
+    assert "master_fallback_used" in (res.certification.tie_break_flags or [])

--- a/tests/test_vfcg/test_warmstart.py
+++ b/tests/test_vfcg/test_warmstart.py
@@ -90,3 +90,29 @@ def test_generate_warmstart_references_removes_duplicates(monkeypatch) -> None:
     )
 
     assert len(refs[0]) == 1
+
+
+def test_generate_warmstart_references_does_not_apply_week_truncation(monkeypatch) -> None:
+    week0 = _week(0)
+    week1 = _week(1)
+
+    def _fake_solve_pricing(**kwargs):
+        calendar = kwargs["calendar"]
+        return _column(calendar.candidates[0]), 1.0
+
+    monkeypatch.setattr("src.vfcg.warmstart.solve_pricing", _fake_solve_pricing)
+
+    capacity_cfg = CapacityConfig()
+    setattr(capacity_cfg, "max_training_weeks", 1)
+
+    refs = generate_warmstart_references(
+        week_data_list=[week0, week1],
+        recommendation_model=_DummyRecommendation(),
+        costs=CostConfig(),
+        capacity_cfg=capacity_cfg,
+        solver_cfg=SolverConfig(),
+        turnover=0.0,
+        n_vectors=3,
+    )
+
+    assert set(refs.keys()) == {0, 1}


### PR DESCRIPTION
### Motivation
- Warm-start should not apply any training-week truncation itself and must return references only for the weeks it is passed. 
- The native-master fallback must produce follower-optimistic schedules consistent with the exact oracle semantics. 
- Fallback results must return finite objective/bound values that reflect the schedules produced. 
- Any run that used the fallback path must be clearly marked unverified in certification.

### Description
- Removed the training-week truncation block from `generate_warmstart_references(...)` so warm-start no longer reads `capacity_cfg.max_training_weeks` and returns references for the weeks it was given (`src/vfcg/warmstart.py`).
- Added a shared helper `build_case_records_from_week_data(...)` in `src/vfcg/oracle.py` and refactored `ExactFollowerOracle.solve(...)` to use it for constructing `CaseRecord` objects.
- Reworked the native-master fallback in `solve_native_master(...)` to call `solve_weekly_optimistic(...)` (using the shared case-record builder) for each week, collect schedules and predicted costs, and compute a finite fallback objective/bound as the mean realized cost over fallback schedules with `gap = nan` and a `_FALLBACK` status suffix (`src/vfcg/master.py`).
- Added a solver-level enforcement in `vfcg_solve(...)` so that if `final_master.is_fallback` is true the `CertificationResult` is rebuilt with `status = "TERMINATED_UNVERIFIED"` and the tie-break flags include `"master_fallback_used"` (`src/vfcg/solver.py`).
- Added tests to assert the new behaviors: `test_generate_warmstart_references_does_not_apply_week_truncation`, `test_native_master_fallback_returns_finite_values_and_uses_optimistic_solver`, and `test_vfcg_solver_downgrades_fallback_certification_status`, and updated existing tests accordingly (`tests/test_vfcg/test_warmstart.py`, `tests/test_vfcg/test_master.py`, `tests/test_vfcg/test_solver.py`).

### Testing
- Ran the VFCG unit tests with `pytest -q tests/test_vfcg` and all tests passed (`28 passed`).
- New/updated unit tests covering warm-start, master fallback, and solver certification behavior were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1fa7aeec832babeac2305b4ae677)