### PR TITLE
Speed up VFCG follower oracle with single-pass solve, symmetry breaking, and solver tuning

### DIFF
--- a/src/solvers/deterministic.py
+++ b/src/solvers/deterministic.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
+from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple
@@ -124,6 +125,44 @@ def _build_weekly_schedule_model(
             model.addConstr(real_load - cap_val <= realized_ot[bid], name=f"real_ot_{bid.day_index}_{bid.site}_{bid.room}")
             model.addConstr(cap_val - real_load <= realized_idle[bid], name=f"real_idle_{bid.day_index}_{bid.site}_{bid.room}")
 
+    # Symmetry breaking: order loads on identical blocks and deferrals within eligibility classes.
+    block_eligible_set: Dict[BlockId, frozenset[int]] = {}
+    for bid in all_block_ids:
+        block_eligible_set[bid] = frozenset(block_cases[bid])
+
+    symmetry_groups: Dict[tuple, list[BlockId]] = defaultdict(list)
+    for bid in all_block_ids:
+        key = (bid.day_index, bid.site, cap[bid], f_cost[bid], block_eligible_set[bid])
+        symmetry_groups[key].append(bid)
+
+    for group_bids in symmetry_groups.values():
+        if len(group_bids) < 2:
+            continue
+        sorted_bids = sorted(group_bids, key=lambda b: b.room)
+        for idx in range(len(sorted_bids) - 1):
+            bid_hi = sorted_bids[idx]
+            bid_lo = sorted_bids[idx + 1]
+            eligible_hi = block_cases[bid_hi]
+            eligible_lo = block_cases[bid_lo]
+            if not eligible_hi or not eligible_lo:
+                continue
+            load_hi = quicksum(float(planning_durations[i]) * x[i, bid_hi] for i in eligible_hi if (i, bid_hi) in x)
+            load_lo = quicksum(float(planning_durations[i]) * x[i, bid_lo] for i in eligible_lo if (i, bid_lo) in x)
+            model.addConstr(load_hi >= load_lo, name=f"sym_load_{bid_hi.day_index}_{bid_hi.room}_{bid_lo.room}")
+
+    elig_class_cases: Dict[frozenset[BlockId], list[int]] = defaultdict(list)
+    for i in range(n_cases):
+        elig = frozenset(case_eligible_blocks.get(i, []))
+        if elig:
+            elig_class_cases[elig].append(i)
+
+    for case_list in elig_class_cases.values():
+        sorted_cases = sorted(case_list)
+        for idx in range(len(sorted_cases) - 1):
+            i1 = sorted_cases[idx]
+            i2 = sorted_cases[idx + 1]
+            model.addConstr(r[i1] <= r[i2], name=f"sym_defer_{i1}_{i2}")
+
     activation = quicksum(f_cost[bid] * v[bid] for bid in all_block_ids)
     deferral = costs.deferral_per_case * quicksum(r[i] for i in range(n_cases))
     predicted_total_cost = (
@@ -223,7 +262,7 @@ def solve_weekly_optimistic(
     pass_a = _build_weekly_schedule_model(
         cases=cases,
         planning_durations=planning_durations,
-        realized_durations=realized_durations,
+        realized_durations=None,
         calendar=calendar,
         costs=costs,
         solver_cfg=solver_cfg,
@@ -326,3 +365,6 @@ def _apply_solver_params(model: gp.Model, cfg: SolverConfig) -> None:
     model.Params.OutputFlag = 1 if cfg.verbose else 0
     model.Params.MIPFocus = 1
     model.Params.Symmetry = 2
+    model.Params.Presolve = 2
+    model.Params.Cuts = 2
+    model.Params.Heuristics = 0.1

--- a/src/vfcg/oracle.py
+++ b/src/vfcg/oracle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from datetime import datetime
 
 import numpy as np
@@ -9,7 +10,7 @@ import numpy as np
 from src.core.config import CapacityConfig, CostConfig, SolverConfig
 from src.core.types import CaseRecord
 from src.estimation.recommendation import RecommendationModel, WeekRecommendationData
-from src.solvers.deterministic import solve_weekly_optimistic
+from src.solvers.deterministic import solve_pricing, solve_weekly_optimistic
 from src.vfcg.types import OracleResult
 
 
@@ -77,4 +78,41 @@ class ExactFollowerOracle:
             realized_cost=float(realized_cost),
             status=status,
             solve_time=float(solve_time),
+        )
+
+    def solve_fast(
+        self,
+        week_data: WeekRecommendationData,
+        w: np.ndarray,
+        recommendation_model: RecommendationModel,
+        costs: CostConfig,
+        capacity_cfg: CapacityConfig,
+        solver_cfg: SolverConfig,
+        turnover: float,
+    ) -> OracleResult:
+        _ = capacity_cfg
+        t0 = time.perf_counter()
+
+        d_post = np.asarray(recommendation_model.compute_post_review(w, week_data), dtype=float)
+        col, predicted_cost = solve_pricing(
+            n_cases=week_data.n_cases,
+            durations=d_post,
+            calendar=week_data.calendar,
+            costs=costs,
+            solver_cfg=solver_cfg,
+            case_eligible_blocks=week_data.case_eligible_blocks,
+            turnover=turnover,
+            model_name=f"vfcg_oracle_fast_w{week_data.week_index}",
+        )
+        if col is None:
+            raise RuntimeError("Exact follower oracle fast solve failed to produce a schedule.")
+
+        realized = np.asarray(week_data.realized, dtype=float)
+        realized_cost = float(col.compute_cost(realized, costs, turnover))
+        return OracleResult(
+            schedule=col,
+            predicted_cost=float(predicted_cost),
+            realized_cost=realized_cost,
+            status="OPTIMAL",
+            solve_time=float(time.perf_counter() - t0),
         )

--- a/src/vfcg/solver.py
+++ b/src/vfcg/solver.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import replace
 
 import numpy as np
 
@@ -28,6 +29,7 @@ def vfcg_solve(
     turnover: float,
 ) -> VFCGResult:
     oracle = ExactFollowerOracle()
+    oracle_solver_cfg = replace(solver_cfg, time_limit_seconds=config.vfcg.oracle_time_limit)
     reference_sets = generate_warmstart_references(
         week_data_list=week_data_list,
         recommendation_model=recommendation_model,
@@ -61,15 +63,14 @@ def vfcg_solve(
 
         if not master_res.is_fallback:
             for wd in week_data_list:
-                oracle_res = oracle.solve(
+                oracle_res = oracle.solve_fast(
                     week_data=wd,
                     w=master_res.weights,
                     recommendation_model=recommendation_model,
                     costs=costs,
                     capacity_cfg=capacity_cfg,
-                    solver_cfg=solver_cfg,
+                    solver_cfg=oracle_solver_cfg,
                     turnover=turnover,
-                    tol=config.vfcg.convergence_tol,
                 )
                 oracle_time_total += oracle_res.solve_time
 
@@ -124,7 +125,7 @@ def vfcg_solve(
         config=config,
         costs=costs,
         capacity_cfg=capacity_cfg,
-        solver_cfg=solver_cfg,
+        solver_cfg=oracle_solver_cfg,
         turnover=turnover,
         master_objective=final_master.objective,
         master_bound=final_master.bound,

--- a/tests/test_vfcg/test_oracle.py
+++ b/tests/test_vfcg/test_oracle.py
@@ -7,7 +7,9 @@ import numpy as np
 from src.core.config import CapacityConfig, CostConfig, SolverConfig
 from src.core.types import BlockCalendar, BlockId, CandidateBlock, CaseRecord
 from src.estimation.recommendation import WeekRecommendationData
-from src.solvers.deterministic import solve_deterministic, solve_weekly_optimistic
+import pytest
+
+from src.solvers.deterministic import solve_deterministic, solve_pricing, solve_weekly_optimistic
 from src.vfcg.oracle import ExactFollowerOracle
 from src.vfcg.types import OracleResult
 
@@ -180,3 +182,96 @@ def test_exact_follower_oracle_uses_post_review_durations_end_to_end() -> None:
     assert assigned_block == BlockId(0, "TGH", "OR1")
     assert np.isclose(result.predicted_cost, 10.0)
     assert np.isclose(result.realized_cost, 0.0)
+
+
+def test_solve_fast_returns_predicted_cost_minimizer() -> None:
+    cases = _single_case()
+    block = CandidateBlock(day_index=0, site="TGH", room="OR1", capacity_minutes=100.0, activation_cost=0.0)
+    week_data = WeekRecommendationData(
+        week_index=3,
+        n_cases=1,
+        features=np.zeros((1, 1), dtype=float),
+        bookings=np.array([100.0], dtype=float),
+        realized=np.array([90.0], dtype=float),
+        L_bounds=np.array([60.0], dtype=float),
+        U_bounds=np.array([180.0], dtype=float),
+        surgeon_codes=[cases[0].surgeon_code],
+        sos2_data=[],
+        case_eligible_blocks={0: [block.id]},
+        calendar=BlockCalendar([block]),
+    )
+    oracle = ExactFollowerOracle()
+    rec_model = _DummyRecommendationModel(returned_d_post=np.array([110.0], dtype=float))
+    costs = CostConfig(overtime_per_minute=1.0, idle_per_minute=1.0, deferral_per_case=1000.0)
+    solver_cfg = SolverConfig(time_limit_seconds=30, mip_gap=0.0, verbose=False)
+
+    fast = oracle.solve_fast(
+        week_data=week_data,
+        w=np.array([0.0], dtype=float),
+        recommendation_model=rec_model,
+        costs=costs,
+        capacity_cfg=CapacityConfig(),
+        solver_cfg=solver_cfg,
+        turnover=0.0,
+    )
+    full = oracle.solve(
+        week_data=week_data,
+        w=np.array([0.0], dtype=float),
+        recommendation_model=rec_model,
+        costs=costs,
+        capacity_cfg=CapacityConfig(),
+        solver_cfg=solver_cfg,
+        turnover=0.0,
+    )
+
+    assert np.isfinite(fast.predicted_cost)
+    assert fast.predicted_cost <= full.predicted_cost + 1e-6
+    assert fast.schedule is not None
+
+
+def test_solve_fast_raises_when_no_schedule_possible() -> None:
+    week_data = WeekRecommendationData(
+        week_index=4,
+        n_cases=1,
+        features=np.zeros((1, 1), dtype=float),
+        bookings=np.array([100.0], dtype=float),
+        realized=np.array([100.0], dtype=float),
+        L_bounds=np.array([60.0], dtype=float),
+        U_bounds=np.array([180.0], dtype=float),
+        surgeon_codes=["S1"],
+        sos2_data=[],
+        case_eligible_blocks={0: []},
+        calendar=BlockCalendar([]),
+    )
+    oracle = ExactFollowerOracle()
+
+    with pytest.raises(RuntimeError):
+        oracle.solve_fast(
+            week_data=week_data,
+            w=np.array([0.0], dtype=float),
+            recommendation_model=_DummyRecommendationModel(returned_d_post=np.array([100.0], dtype=float)),
+            costs=CostConfig(),
+            capacity_cfg=CapacityConfig(),
+            solver_cfg=SolverConfig(time_limit_seconds=30, mip_gap=0.0, verbose=False),
+            turnover=0.0,
+        )
+
+
+def test_symmetry_breaking_assigns_to_first_room() -> None:
+    block_a = CandidateBlock(day_index=0, site="TGH", room="OR1", capacity_minutes=100.0, activation_cost=0.0)
+    block_b = CandidateBlock(day_index=0, site="TGH", room="OR2", capacity_minutes=100.0, activation_cost=0.0)
+    calendar = BlockCalendar([block_a, block_b])
+    eligible = {0: [block_a.id, block_b.id]}
+    col, _ = solve_pricing(
+        n_cases=1,
+        durations=np.array([100.0], dtype=float),
+        calendar=calendar,
+        costs=CostConfig(overtime_per_minute=1.0, idle_per_minute=1.0, deferral_per_case=1000.0),
+        solver_cfg=SolverConfig(time_limit_seconds=30, mip_gap=0.0, verbose=False),
+        case_eligible_blocks=eligible,
+        turnover=0.0,
+        model_name="symmetry_test",
+    )
+    assert col is not None
+    assigned_block = next(iter(col.z_assign))[1]
+    assert assigned_block == block_a.id

--- a/tests/test_vfcg/test_solver.py
+++ b/tests/test_vfcg/test_solver.py
@@ -78,6 +78,9 @@ def test_trivial_instance_terminates_one_iteration(monkeypatch) -> None:
         def solve(self, **kwargs):
             return OracleResult(schedule=col, predicted_cost=10.0, realized_cost=10.0, status="OPTIMAL", solve_time=0.01)
 
+        def solve_fast(self, **kwargs):
+            return self.solve(**kwargs)
+
     monkeypatch.setattr("src.vfcg.solver.ExactFollowerOracle", _Oracle)
     monkeypatch.setattr(
         "src.vfcg.solver.certify",
@@ -132,6 +135,9 @@ def test_detects_violated_week_and_adds_cut(monkeypatch) -> None:
             if self.k == 1:
                 return OracleResult(schedule=better_col, predicted_cost=0.0, realized_cost=0.0, status="OPTIMAL", solve_time=0.01)
             return OracleResult(schedule=better_col, predicted_cost=10.0, realized_cost=0.0, status="OPTIMAL", solve_time=0.01)
+
+        def solve_fast(self, **kwargs):
+            return self.solve(**kwargs)
 
     monkeypatch.setattr("src.vfcg.solver.ExactFollowerOracle", _Oracle)
     monkeypatch.setattr(


### PR DESCRIPTION
### Motivation

- The VFCG follower oracle previously built and solved two full weekly MIPs per call, which is wasteful for the usual VFCG separation check that only needs a predicted-cost minimizer. 
- The optimistic first pass unnecessarily included realized-duration variables, inflating model size and presolve time. 
- Symmetric block/case structure and conservative solver defaults caused large branch-and-bound trees and slower solves, and the oracle should respect the shorter `vfcg.oracle_time_limit`.

### Description

- Added a single-pass fast oracle `ExactFollowerOracle.solve_fast()` in `src/vfcg/oracle.py` which computes `d_post`, calls `solve_pricing`, computes realized cost from the returned `ScheduleColumn`, and returns an `OracleResult` (new import of `solve_pricing` and `time`).
- Updated the VFCG loop in `src/vfcg/solver.py` to use `solve_fast()` for per-week separation and to create an oracle-specific solver config via `replace(solver_cfg, time_limit_seconds=config.vfcg.oracle_time_limit)` that is passed to oracle calls and certification.
- Reduced optimistic pass A model size by passing `realized_durations=None` in `solve_weekly_optimistic`, and added explicit symmetry-breaking constraints (identical-block load ordering and deferral ordering within eligibility classes) in `_build_weekly_schedule_model` of `src/solvers/deterministic.py`, with `defaultdict` imported.
- Tuned solver parameters in `_apply_solver_params` by enabling aggressive presolve and cuts and setting a heuristic budget (`Presolve=2`, `Cuts=2`, `Heuristics=0.1`), and added/updated unit tests to cover `solve_fast` behavior, the failure path when no schedule is possible, symmetry-breaking behavior, and adjusted test mocks to expose `solve_fast()`.

### Testing

- Ran `pytest tests/test_vfcg/ -v` and all tests passed (`31 passed`).
- Ran `pytest tests/test_estimation/ -v` and all tests passed (`47 passed`).
- The new `tests/test_vfcg/test_oracle.py` cases exercise `solve_fast`, the no-schedule error path, and the symmetry-breaking assignment, and the modified `tests/test_vfcg/test_solver.py` mocks ensure compatibility with the new oracle API.
- No other automated test failures were observed in the repository test suite runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccbc3c7624832bb145d1c40cf6980f)